### PR TITLE
Project definition rewrite.

### DIFF
--- a/code/build.sbt
+++ b/code/build.sbt
@@ -1,0 +1,15 @@
+version in ThisBuild := "0.4.14-SNAPSHOT"
+
+val NGSNexus     = "NGS Nexus"     at "http://ngs.hr/nexus/content/groups/public/"
+val NGSReleases  = "NGS Releases"  at "http://ngs.hr/nexus/content/repositories/releases/"
+val NGSSnapshots = "NGS Snapshots" at "http://ngs.hr/nexus/content/repositories/snapshots/"
+
+resolvers in ThisBuild := Seq(NGSNexus, NGSSnapshots)
+
+externalResolvers in ThisBuild := Resolver.withDefaultResolvers(resolvers.value, mavenCentral = false)
+
+publishTo in ThisBuild := Some(
+      if (version.value endsWith "SNAPSHOT") NGSSnapshots else NGSReleases
+    )
+
+credentials in ThisBuild += Credentials(Path.userHome / ".config" / "dsl-client-java" / "nexus.config")

--- a/code/http/src/main/java/com/dslplatform/client/MapServiceLocator.java
+++ b/code/http/src/main/java/com/dslplatform/client/MapServiceLocator.java
@@ -11,8 +11,17 @@ class MapServiceLocator implements ServiceLocator {
     private final Map<Class<?>, Object> components = new LinkedHashMap<Class<?>, Object>();
     private final static boolean cacheResult = true;
 
-    public MapServiceLocator() {
+    MapServiceLocator() {
         components.put(ServiceLocator.class, this);
+    }
+
+    MapServiceLocator(final Map<Class<?>, Object> initialComponents) {
+        components.put(ServiceLocator.class, this);
+        components.putAll(initialComponents);
+    }
+
+    boolean contains(final Class<?> clazz) {
+        return components.containsKey(clazz);
     }
 
     @Override
@@ -22,7 +31,7 @@ class MapServiceLocator implements ServiceLocator {
     }
 
     private void cacheIf(final Class<?> clazz, final Object service) {
-         if(cacheResult && service != null)
+         if (cacheResult && service != null)
            register(clazz, service);
     }
 
@@ -46,7 +55,7 @@ class MapServiceLocator implements ServiceLocator {
     }
 
     private Object tryResolve(final Class<?> target) {
-        for(final Constructor<?> c : target.getConstructors()) {
+        for (final Constructor<?> c : target.getConstructors()) {
             final ArrayList<Object> args = new ArrayList<Object>();
             boolean success = true;
             for(final Class<?> p : c.getParameterTypes()) {
@@ -58,7 +67,7 @@ class MapServiceLocator implements ServiceLocator {
                 args.add(a);
             }
 
-            if(success) {
+            if (success) {
                 try {
                    final Object instance = c.newInstance(args.toArray());
                    cacheIf(target, instance);
@@ -70,6 +79,11 @@ class MapServiceLocator implements ServiceLocator {
             }
         }
         return null;
+    }
+
+    <T> T registerAndReturnInstance(final Class<T> target, final T service) {
+        components.put(target, service);
+        return service;
     }
 
     public <T> MapServiceLocator register(final Class<T> target, final Object service) {

--- a/code/http/src/main/java/com/dslplatform/client/ProjectSettings.java
+++ b/code/http/src/main/java/com/dslplatform/client/ProjectSettings.java
@@ -2,7 +2,10 @@ package com.dslplatform.client;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Map;
 import java.util.Properties;
+
+import org.slf4j.Logger;
 
 /**
  * Project.ini key->value pairs
@@ -10,15 +13,28 @@ import java.util.Properties;
 public class ProjectSettings {
     private final Properties properties;
 
+    private final Logger logger;
+
     /**
      * Stream to project.ini file
      *
      * @param iniStream    project.ini stream
      * @throws IOException in case of error reading stream
      */
-    public ProjectSettings(final InputStream iniStream) throws IOException {
+    public ProjectSettings(final Logger logger, final InputStream iniStream)
+            throws IOException {
         properties = new Properties();
+        this.logger = logger;
         properties.load(iniStream);
+        if (logger.isDebugEnabled()) {
+            for (final Map.Entry<Object, Object> prop : properties.entrySet()) {
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Setting [" + prop.getKey() + "] = " + prop.getValue());
+                } else {
+                    logger.debug("Setting [" + prop.getKey() + "]");
+                }
+            }
+        }
     }
 
     /**
@@ -29,6 +45,7 @@ public class ProjectSettings {
      * @return         found value
      */
     public String get(final String property) {
+        logger.trace("Getting property [" + property + "]");
         return properties.getProperty(property);
     }
 }

--- a/code/http/src/test/java/com/dslplatform/client/BootstrapTest.java
+++ b/code/http/src/test/java/com/dslplatform/client/BootstrapTest.java
@@ -1,0 +1,40 @@
+package com.dslplatform.client;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.dslplatform.patterns.ServiceLocator;
+
+public class BootstrapTest {
+
+    @Test
+    public void withDefaultLoggerAndEC() throws Exception {
+        final ServiceLocator locator = Bootstrap.init(this.getClass().getResourceAsStream("/mockproject.ini"));
+        final ProjectSettings ps = locator.resolve(ProjectSettings.class);
+        assertEquals("Project id matches", ps.get("project-id"), "0e13d168-1e2d-6ced-82f0-b9e693acde3e");
+    }
+
+    @Test
+    public void withCustomLoggerAndEC() throws Exception {
+        final String loggerName = "testLogger";
+        final Logger logger = LoggerFactory.getLogger(loggerName);
+        final Map<Class<?>, Object> initialComponents = new HashMap<Class<?>, Object>();
+        final ExecutorService newSingleThreadExecutor = Executors.newSingleThreadExecutor();
+        initialComponents.put(ExecutorService.class, newSingleThreadExecutor);
+        initialComponents.put(Logger.class, logger);
+
+        final ServiceLocator locator = Bootstrap.init(this.getClass().getResourceAsStream("/mockproject.ini"), initialComponents);
+
+        assertSame("Logger instance matches.", locator.resolve(Logger.class), logger);
+        assertSame("ExecutionService matches.", locator.resolve(ExecutorService.class), newSingleThreadExecutor);
+    }
+
+}

--- a/code/http/src/test/java/com/dslplatform/client/MapServiceLocatorTest.java
+++ b/code/http/src/test/java/com/dslplatform/client/MapServiceLocatorTest.java
@@ -1,0 +1,32 @@
+package com.dslplatform.client;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MapServiceLocatorTest {
+
+    @Test
+    public void withDefaultLoggerAndEC() throws Exception {
+        Map<Class<?>, Object> initialComponents = new HashMap<Class<?>, Object>();
+        initialComponents.put(ExecutorService.class, Executors.newSingleThreadExecutor());
+        final String testLoggerName = "testLogger";
+        initialComponents.put(Logger.class, LoggerFactory.getLogger(testLoggerName));
+        final MapServiceLocator mapServiceLocator = new MapServiceLocator(initialComponents);
+        final ExecutorService executorService = mapServiceLocator.resolve(ExecutorService.class);
+        final Logger logger = mapServiceLocator.resolve(Logger.class);
+
+
+        System.out.println(logger.getName());
+        assertTrue("Executor matches", executorService instanceof ExecutorService);
+        assertTrue("Logger matches", logger.getName().equals(testLoggerName));
+    }
+
+}

--- a/code/http/src/test/resources/mockproject.ini
+++ b/code/http/src/test/resources/mockproject.ini
@@ -1,0 +1,4 @@
+username=user@domain.com
+project-id=0e13d168-1e2d-6ced-82f0-b9e693acde3e
+api-url=https://api_server/application_name/
+package-name=com.example


### PR DESCRIPTION
Bootstrap.getLocator is no longer deprecated, warning is moved to informal sentence in javadoc.

Bootstrap can now be initialized with custom ExecutorService and Logger.

New constructor for MapServiceLocator that takes initial map.

ProjectSettings takes, and uses, a logger.

Unit test for new Bootstrap functionality.
