### PR TITLE
Added JSON serialization tests.

### DIFF
--- a/core/src/main/java/com/dslplatform/client/Utils.java
+++ b/core/src/main/java/com/dslplatform/client/Utils.java
@@ -166,7 +166,7 @@ public class Utils {
 		IS_ANDROID = System.getProperty("java.runtime.name").toLowerCase(Locale.ENGLISH).contains("android");
 		boolean foundJackson = false;
 		try {
-			Class.forName("com.fasterxml.jackson.databind.ObjectMapper", false, null);
+			Class.forName("com.fasterxml.jackson.databind.ObjectMapper", false, Thread.currentThread().getContextClassLoader());
 			foundJackson = true;
 		} catch(Exception ignore) {
 		}

--- a/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/BinaryAsserts.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/BinaryAsserts.java
@@ -1,0 +1,280 @@
+package com.dslplatform.ocd.javaasserts;
+
+import org.junit.Assert;
+
+public class BinaryAsserts {
+    static void assertSingleEquals(final String message, final byte[] expected, final byte[] actual) {
+        if (expected.length != actual.length) {
+            Assert.fail(message + "expected was a Binary of " + expected.length + " bytes, but actual was a Binary of " + actual.length + " bytes");
+        }
+
+        for (int i = 0; i < expected.length; i++) {
+            if (expected[i] != actual[i]) {
+                Assert.fail(message + "Binary differs at index " + i + ": expected was \"" + expected[i] + "\", but actual was \"" + actual[i] + "\"");
+            }
+        }
+    }
+
+    static void assertOneEquals(final String message, final byte[] expected, final byte[] actual) {
+        if (expected == null) Assert.fail(message + "expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        if (expected == actual) return;
+        if (actual == null) Assert.fail(message + "expected was a Binary of " + expected.length + " bytes, but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertOneEquals(final byte[] expected, final byte[] actual) {
+        assertOneEquals("OneBinary mismatch: ", expected, actual);
+    }
+
+    private static void assertNullableEquals(final String message, final byte[] expected, final byte[] actual) {
+        if (expected == actual) return;
+        if (expected == null) Assert.fail(message + "expected was <null>, but actual was a Binary of " + actual.length + " bytes");
+        if (actual == null) Assert.fail(message + "expected was a Binary of " + expected.length + " bytes, but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertNullableEquals(final byte[] expected, final byte[] actual) {
+        assertNullableEquals("NullableBinary mismatch: ", expected, actual);
+    }
+
+    private static void assertArrayOfOneEquals(final String message, final byte[][] expecteds, final byte[][] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfOneEquals(final String message, final byte[][] expecteds, final byte[][] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        for (int i = 0; i < expecteds.length; i ++) {
+            if (expecteds[i] == null) {
+                Assert.fail(message + "expecteds contained a <null> element at index " + i + " - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+            }
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfOneEquals(final byte[][] expecteds, final byte[][] actuals) {
+        assertOneArrayOfOneEquals("OneArrayOfOneBinary mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfOneEquals(final String message, final byte[][] expecteds, final byte[][] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfOneEquals(final byte[][] expecteds, final byte[][] actuals) {
+        assertNullableArrayOfOneEquals("NullableArrayOfOneBinary mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertArrayOfNullableEquals(final String message, final byte[][] expecteds, final byte[][] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfNullableEquals(final String message, final byte[][] expecteds, final byte[][] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfNullableEquals(final byte[][] expecteds, final byte[][] actuals) {
+        assertOneArrayOfNullableEquals("OneArrayOfNullableBinary mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfNullableEquals(final String message, final byte[][] expecteds, final byte[][] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfNullableEquals(final byte[][] expecteds, final byte[][] actuals) {
+        assertNullableArrayOfNullableEquals("NullableArrayOfNullableBinary mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfOneEquals(final String message, final java.util.List<byte[]> expecteds, final java.util.List<byte[]> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<byte[]> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<byte[]> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final byte[] expected = expectedsIterator.next();
+            final byte[] actual = actualsIterator.next();
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfOneEquals(final String message, final java.util.List<byte[]> expecteds, final java.util.List<byte[]> actuals) {
+        int i = 0;
+        for (final byte[] expected : expecteds) {
+            if (expected == null) {
+                Assert.fail(message + "element mismatch occurred at index " + i + ": expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+            }
+            i++;
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfOneEquals(final java.util.List<byte[]> expecteds, final java.util.List<byte[]> actuals) {
+        assertOneListOfOneEquals("OneListOfOneBinary mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfOneEquals(final String message, final java.util.List<byte[]> expecteds, final java.util.List<byte[]> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfOneEquals(final java.util.List<byte[]> expecteds, final java.util.List<byte[]> actuals) {
+        assertNullableListOfOneEquals("NullableListOfOneBinary mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfNullableEquals(final String message, final java.util.List<byte[]> expecteds, final java.util.List<byte[]> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<byte[]> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<byte[]> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final byte[] expected = expectedsIterator.next();
+            final byte[] actual = actualsIterator.next();
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfNullableEquals(final String message, final java.util.List<byte[]> expecteds, final java.util.List<byte[]> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfNullableEquals(final java.util.List<byte[]> expecteds, final java.util.List<byte[]> actuals) {
+        assertOneListOfNullableEquals("OneListOfNullableBinary mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfNullableEquals(final String message, final java.util.List<byte[]> expecteds, final java.util.List<byte[]> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfNullableEquals(final java.util.List<byte[]> expecteds, final java.util.List<byte[]> actuals) {
+        assertNullableListOfNullableEquals("NullableListOfNullableBinary mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfOneEquals(final String message, final java.util.Set<byte[]> expecteds, final java.util.Set<byte[]> actuals) {
+        if (actuals.contains(null)) {
+            Assert.fail(message + "actuals contained a <null> element");
+        }
+
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        expectedsLoop: for (final byte[] expected : expecteds) {
+            if (actuals.contains(expected)) continue;
+            for (final byte[] actual : actuals) {
+                try {
+                    assertOneEquals(expected, actual);
+                    continue expectedsLoop;
+                }
+                catch (final AssertionError e) {}
+            }
+            Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+        }
+    }
+
+    private static void assertOneSetOfOneEquals(final String message, final java.util.Set<byte[]> expecteds, final java.util.Set<byte[]> actuals) {
+        if (expecteds.contains(null)) {
+            Assert.fail(message + "expecteds contained a <null> element - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfOneEquals(final java.util.Set<byte[]> expecteds, final java.util.Set<byte[]> actuals) {
+        assertOneSetOfOneEquals("OneSetOfOneBinary mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfOneEquals(final String message, final java.util.Set<byte[]> expecteds, final java.util.Set<byte[]> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfOneEquals(final java.util.Set<byte[]> expecteds, final java.util.Set<byte[]> actuals) {
+        assertNullableSetOfOneEquals("NullableSetOfOneBinary mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfNullableEquals(final String message, final java.util.Set<byte[]> expecteds, final java.util.Set<byte[]> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        expectedsLoop: for (final byte[] expected : expecteds) {
+            if (actuals.contains(expected)) continue;
+            for (final byte[] actual : actuals) {
+                try {
+                    assertNullableEquals(expected, actual);
+                    continue expectedsLoop;
+                }
+                catch (final AssertionError e) {}
+            }
+            Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+        }
+    }
+
+    private static void assertOneSetOfNullableEquals(final String message, final java.util.Set<byte[]> expecteds, final java.util.Set<byte[]> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfNullableEquals(final java.util.Set<byte[]> expecteds, final java.util.Set<byte[]> actuals) {
+        assertOneSetOfNullableEquals("OneSetOfNullableBinary mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfNullableEquals(final String message, final java.util.Set<byte[]> expecteds, final java.util.Set<byte[]> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfNullableEquals(final java.util.Set<byte[]> expecteds, final java.util.Set<byte[]> actuals) {
+        assertNullableSetOfNullableEquals("NullableSetOfNullableBinary mismatch: ", expecteds, actuals);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/BooleanAsserts.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/BooleanAsserts.java
@@ -1,0 +1,256 @@
+package com.dslplatform.ocd.javaasserts;
+
+import org.junit.Assert;
+
+public class BooleanAsserts {
+    static void assertSingleEquals(final String message, final boolean expected, final boolean actual) {
+        if (expected == actual) return;
+        Assert.fail(message + "expected was \"" + expected + "\", but actual was \"" + actual + "\"");
+    }
+
+    static void assertOneEquals(final String message, final boolean expected, final boolean actual) {
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertOneEquals(final boolean expected, final boolean actual) {
+        assertOneEquals("OneBoolean mismatch: ", expected, actual);
+    }
+
+    private static void assertNullableEquals(final String message, final Boolean expected, final Boolean actual) {
+        if (expected == actual) return;
+        if (expected == null) Assert.fail(message + "expected was <null>, but actual was \"" + actual + "\"");
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertNullableEquals(final Boolean expected, final Boolean actual) {
+        assertNullableEquals("NullableBoolean mismatch: ", expected, actual);
+    }
+
+    private static void assertArrayOfOneEquals(final String message, final boolean[] expecteds, final boolean[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfOneEquals(final String message, final boolean[] expecteds, final boolean[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfOneEquals(final boolean[] expecteds, final boolean[] actuals) {
+        assertOneArrayOfOneEquals("OneArrayOfOneBoolean mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfOneEquals(final String message, final boolean[] expecteds, final boolean[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfOneEquals(final boolean[] expecteds, final boolean[] actuals) {
+        assertNullableArrayOfOneEquals("NullableArrayOfOneBoolean mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertArrayOfNullableEquals(final String message, final Boolean[] expecteds, final Boolean[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfNullableEquals(final String message, final Boolean[] expecteds, final Boolean[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfNullableEquals(final Boolean[] expecteds, final Boolean[] actuals) {
+        assertOneArrayOfNullableEquals("OneArrayOfNullableBoolean mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfNullableEquals(final String message, final Boolean[] expecteds, final Boolean[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfNullableEquals(final Boolean[] expecteds, final Boolean[] actuals) {
+        assertNullableArrayOfNullableEquals("NullableArrayOfNullableBoolean mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfOneEquals(final String message, final java.util.List<Boolean> expecteds, final java.util.List<Boolean> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<Boolean> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<Boolean> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final Boolean expected = expectedsIterator.next();
+            final Boolean actual = actualsIterator.next();
+            if (actual == null) {
+                Assert.fail(message + "element mismatch occurred at index " + i + ": expected was \"" + expected + "\", but actual was <null>");
+            }
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expected.booleanValue(), actual.booleanValue());
+        }
+    }
+
+    private static void assertOneListOfOneEquals(final String message, final java.util.List<Boolean> expecteds, final java.util.List<Boolean> actuals) {
+        int i = 0;
+        for (final Boolean expected : expecteds) {
+            if (expected == null) {
+                Assert.fail(message + "element mismatch occurred at index " + i + ": expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+            }
+            i++;
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfOneEquals(final java.util.List<Boolean> expecteds, final java.util.List<Boolean> actuals) {
+        assertOneListOfOneEquals("OneListOfOneBoolean mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfOneEquals(final String message, final java.util.List<Boolean> expecteds, final java.util.List<Boolean> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfOneEquals(final java.util.List<Boolean> expecteds, final java.util.List<Boolean> actuals) {
+        assertNullableListOfOneEquals("NullableListOfOneBoolean mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfNullableEquals(final String message, final java.util.List<Boolean> expecteds, final java.util.List<Boolean> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<Boolean> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<Boolean> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final Boolean expected = expectedsIterator.next();
+            final Boolean actual = actualsIterator.next();
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfNullableEquals(final String message, final java.util.List<Boolean> expecteds, final java.util.List<Boolean> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfNullableEquals(final java.util.List<Boolean> expecteds, final java.util.List<Boolean> actuals) {
+        assertOneListOfNullableEquals("OneListOfNullableBoolean mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfNullableEquals(final String message, final java.util.List<Boolean> expecteds, final java.util.List<Boolean> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfNullableEquals(final java.util.List<Boolean> expecteds, final java.util.List<Boolean> actuals) {
+        assertNullableListOfNullableEquals("NullableListOfNullableBoolean mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfOneEquals(final String message, final java.util.Set<Boolean> expecteds, final java.util.Set<Boolean> actuals) {
+        if (actuals.contains(null)) {
+            Assert.fail(message + "actuals contained a <null> element");
+        }
+
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        for (final Boolean expected : expecteds) {
+            if (!actuals.contains(expected)) {
+                Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+            }
+        }
+    }
+
+    private static void assertOneSetOfOneEquals(final String message, final java.util.Set<Boolean> expecteds, final java.util.Set<Boolean> actuals) {
+        if (expecteds.contains(null)) {
+            Assert.fail(message + "expecteds contained a <null> element - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfOneEquals(final java.util.Set<Boolean> expecteds, final java.util.Set<Boolean> actuals) {
+        assertOneSetOfOneEquals("OneSetOfOneBoolean mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfOneEquals(final String message, final java.util.Set<Boolean> expecteds, final java.util.Set<Boolean> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfOneEquals(final java.util.Set<Boolean> expecteds, final java.util.Set<Boolean> actuals) {
+        assertNullableSetOfOneEquals("NullableSetOfOneBoolean mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfNullableEquals(final String message, final java.util.Set<Boolean> expecteds, final java.util.Set<Boolean> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        for (final Boolean expected : expecteds) {
+            if (!actuals.contains(expected)) {
+                Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+            }
+        }
+    }
+
+    private static void assertOneSetOfNullableEquals(final String message, final java.util.Set<Boolean> expecteds, final java.util.Set<Boolean> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfNullableEquals(final java.util.Set<Boolean> expecteds, final java.util.Set<Boolean> actuals) {
+        assertOneSetOfNullableEquals("OneSetOfNullableBoolean mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfNullableEquals(final String message, final java.util.Set<Boolean> expecteds, final java.util.Set<Boolean> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfNullableEquals(final java.util.Set<Boolean> expecteds, final java.util.Set<Boolean> actuals) {
+        assertNullableSetOfNullableEquals("NullableSetOfNullableBoolean mismatch: ", expecteds, actuals);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/DateAsserts.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/DateAsserts.java
@@ -1,0 +1,261 @@
+package com.dslplatform.ocd.javaasserts;
+
+import org.junit.Assert;
+
+public class DateAsserts {
+    static void assertSingleEquals(final String message, final org.joda.time.LocalDate expected, final org.joda.time.LocalDate actual) {
+        if (expected.equals(actual)) return;
+        Assert.fail(message + "expected was \"" + expected + "\", but actual was \"" + actual + "\"");
+    }
+
+    static void assertOneEquals(final String message, final org.joda.time.LocalDate expected, final org.joda.time.LocalDate actual) {
+        if (expected == null) Assert.fail(message + "expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        if (expected == actual) return;
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertOneEquals(final org.joda.time.LocalDate expected, final org.joda.time.LocalDate actual) {
+        assertOneEquals("OneDate mismatch: ", expected, actual);
+    }
+
+    private static void assertNullableEquals(final String message, final org.joda.time.LocalDate expected, final org.joda.time.LocalDate actual) {
+        if (expected == actual) return;
+        if (expected == null) Assert.fail(message + "expected was <null>, but actual was \"" + actual + "\"");
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertNullableEquals(final org.joda.time.LocalDate expected, final org.joda.time.LocalDate actual) {
+        assertNullableEquals("NullableDate mismatch: ", expected, actual);
+    }
+
+    private static void assertArrayOfOneEquals(final String message, final org.joda.time.LocalDate[] expecteds, final org.joda.time.LocalDate[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfOneEquals(final String message, final org.joda.time.LocalDate[] expecteds, final org.joda.time.LocalDate[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        for (int i = 0; i < expecteds.length; i ++) {
+            if (expecteds[i] == null) {
+                Assert.fail(message + "expecteds contained a <null> element at index " + i + " - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+            }
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfOneEquals(final org.joda.time.LocalDate[] expecteds, final org.joda.time.LocalDate[] actuals) {
+        assertOneArrayOfOneEquals("OneArrayOfOneDate mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfOneEquals(final String message, final org.joda.time.LocalDate[] expecteds, final org.joda.time.LocalDate[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfOneEquals(final org.joda.time.LocalDate[] expecteds, final org.joda.time.LocalDate[] actuals) {
+        assertNullableArrayOfOneEquals("NullableArrayOfOneDate mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertArrayOfNullableEquals(final String message, final org.joda.time.LocalDate[] expecteds, final org.joda.time.LocalDate[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfNullableEquals(final String message, final org.joda.time.LocalDate[] expecteds, final org.joda.time.LocalDate[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfNullableEquals(final org.joda.time.LocalDate[] expecteds, final org.joda.time.LocalDate[] actuals) {
+        assertOneArrayOfNullableEquals("OneArrayOfNullableDate mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfNullableEquals(final String message, final org.joda.time.LocalDate[] expecteds, final org.joda.time.LocalDate[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfNullableEquals(final org.joda.time.LocalDate[] expecteds, final org.joda.time.LocalDate[] actuals) {
+        assertNullableArrayOfNullableEquals("NullableArrayOfNullableDate mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfOneEquals(final String message, final java.util.List<org.joda.time.LocalDate> expecteds, final java.util.List<org.joda.time.LocalDate> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<org.joda.time.LocalDate> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<org.joda.time.LocalDate> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final org.joda.time.LocalDate expected = expectedsIterator.next();
+            final org.joda.time.LocalDate actual = actualsIterator.next();
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfOneEquals(final String message, final java.util.List<org.joda.time.LocalDate> expecteds, final java.util.List<org.joda.time.LocalDate> actuals) {
+        int i = 0;
+        for (final org.joda.time.LocalDate expected : expecteds) {
+            if (expected == null) {
+                Assert.fail(message + "element mismatch occurred at index " + i + ": expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+            }
+            i++;
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfOneEquals(final java.util.List<org.joda.time.LocalDate> expecteds, final java.util.List<org.joda.time.LocalDate> actuals) {
+        assertOneListOfOneEquals("OneListOfOneDate mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfOneEquals(final String message, final java.util.List<org.joda.time.LocalDate> expecteds, final java.util.List<org.joda.time.LocalDate> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfOneEquals(final java.util.List<org.joda.time.LocalDate> expecteds, final java.util.List<org.joda.time.LocalDate> actuals) {
+        assertNullableListOfOneEquals("NullableListOfOneDate mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfNullableEquals(final String message, final java.util.List<org.joda.time.LocalDate> expecteds, final java.util.List<org.joda.time.LocalDate> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<org.joda.time.LocalDate> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<org.joda.time.LocalDate> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final org.joda.time.LocalDate expected = expectedsIterator.next();
+            final org.joda.time.LocalDate actual = actualsIterator.next();
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfNullableEquals(final String message, final java.util.List<org.joda.time.LocalDate> expecteds, final java.util.List<org.joda.time.LocalDate> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfNullableEquals(final java.util.List<org.joda.time.LocalDate> expecteds, final java.util.List<org.joda.time.LocalDate> actuals) {
+        assertOneListOfNullableEquals("OneListOfNullableDate mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfNullableEquals(final String message, final java.util.List<org.joda.time.LocalDate> expecteds, final java.util.List<org.joda.time.LocalDate> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfNullableEquals(final java.util.List<org.joda.time.LocalDate> expecteds, final java.util.List<org.joda.time.LocalDate> actuals) {
+        assertNullableListOfNullableEquals("NullableListOfNullableDate mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfOneEquals(final String message, final java.util.Set<org.joda.time.LocalDate> expecteds, final java.util.Set<org.joda.time.LocalDate> actuals) {
+        if (actuals.contains(null)) {
+            Assert.fail(message + "actuals contained a <null> element");
+        }
+
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        for (final org.joda.time.LocalDate expected : expecteds) {
+            if (!actuals.contains(expected)) {
+                Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+            }
+        }
+    }
+
+    private static void assertOneSetOfOneEquals(final String message, final java.util.Set<org.joda.time.LocalDate> expecteds, final java.util.Set<org.joda.time.LocalDate> actuals) {
+        if (expecteds.contains(null)) {
+            Assert.fail(message + "expecteds contained a <null> element - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfOneEquals(final java.util.Set<org.joda.time.LocalDate> expecteds, final java.util.Set<org.joda.time.LocalDate> actuals) {
+        assertOneSetOfOneEquals("OneSetOfOneDate mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfOneEquals(final String message, final java.util.Set<org.joda.time.LocalDate> expecteds, final java.util.Set<org.joda.time.LocalDate> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfOneEquals(final java.util.Set<org.joda.time.LocalDate> expecteds, final java.util.Set<org.joda.time.LocalDate> actuals) {
+        assertNullableSetOfOneEquals("NullableSetOfOneDate mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfNullableEquals(final String message, final java.util.Set<org.joda.time.LocalDate> expecteds, final java.util.Set<org.joda.time.LocalDate> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        for (final org.joda.time.LocalDate expected : expecteds) {
+            if (!actuals.contains(expected)) {
+                Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+            }
+        }
+    }
+
+    private static void assertOneSetOfNullableEquals(final String message, final java.util.Set<org.joda.time.LocalDate> expecteds, final java.util.Set<org.joda.time.LocalDate> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfNullableEquals(final java.util.Set<org.joda.time.LocalDate> expecteds, final java.util.Set<org.joda.time.LocalDate> actuals) {
+        assertOneSetOfNullableEquals("OneSetOfNullableDate mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfNullableEquals(final String message, final java.util.Set<org.joda.time.LocalDate> expecteds, final java.util.Set<org.joda.time.LocalDate> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfNullableEquals(final java.util.Set<org.joda.time.LocalDate> expecteds, final java.util.Set<org.joda.time.LocalDate> actuals) {
+        assertNullableSetOfNullableEquals("NullableSetOfNullableDate mismatch: ", expecteds, actuals);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/DecimalAsserts.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/DecimalAsserts.java
@@ -1,0 +1,273 @@
+package com.dslplatform.ocd.javaasserts;
+
+import org.junit.Assert;
+
+public class DecimalAsserts {
+    static void assertSingleEquals(final String message, final java.math.BigDecimal expected, final java.math.BigDecimal actual) {
+        if (expected == actual || expected.compareTo(actual) == 0) return;
+        Assert.fail(message + "expected was \"" + expected + "\", but actual was \"" + actual + "\"");
+    }
+
+    static void assertOneEquals(final String message, final java.math.BigDecimal expected, final java.math.BigDecimal actual) {
+        if (expected == null) Assert.fail(message + "expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        if (expected == actual) return;
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertOneEquals(final java.math.BigDecimal expected, final java.math.BigDecimal actual) {
+        assertOneEquals("OneDecimal mismatch: ", expected, actual);
+    }
+
+    private static void assertNullableEquals(final String message, final java.math.BigDecimal expected, final java.math.BigDecimal actual) {
+        if (expected == actual) return;
+        if (expected == null) Assert.fail(message + "expected was <null>, but actual was \"" + actual + "\"");
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertNullableEquals(final java.math.BigDecimal expected, final java.math.BigDecimal actual) {
+        assertNullableEquals("NullableDecimal mismatch: ", expected, actual);
+    }
+
+    private static void assertArrayOfOneEquals(final String message, final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfOneEquals(final String message, final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        for (int i = 0; i < expecteds.length; i ++) {
+            if (expecteds[i] == null) {
+                Assert.fail(message + "expecteds contained a <null> element at index " + i + " - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+            }
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfOneEquals(final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        assertOneArrayOfOneEquals("OneArrayOfOneDecimal mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfOneEquals(final String message, final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfOneEquals(final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        assertNullableArrayOfOneEquals("NullableArrayOfOneDecimal mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertArrayOfNullableEquals(final String message, final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfNullableEquals(final String message, final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfNullableEquals(final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        assertOneArrayOfNullableEquals("OneArrayOfNullableDecimal mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfNullableEquals(final String message, final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfNullableEquals(final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        assertNullableArrayOfNullableEquals("NullableArrayOfNullableDecimal mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfOneEquals(final String message, final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<java.math.BigDecimal> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<java.math.BigDecimal> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final java.math.BigDecimal expected = expectedsIterator.next();
+            final java.math.BigDecimal actual = actualsIterator.next();
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfOneEquals(final String message, final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        int i = 0;
+        for (final java.math.BigDecimal expected : expecteds) {
+            if (expected == null) {
+                Assert.fail(message + "element mismatch occurred at index " + i + ": expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+            }
+            i++;
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfOneEquals(final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        assertOneListOfOneEquals("OneListOfOneDecimal mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfOneEquals(final String message, final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfOneEquals(final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        assertNullableListOfOneEquals("NullableListOfOneDecimal mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfNullableEquals(final String message, final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<java.math.BigDecimal> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<java.math.BigDecimal> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final java.math.BigDecimal expected = expectedsIterator.next();
+            final java.math.BigDecimal actual = actualsIterator.next();
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfNullableEquals(final String message, final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfNullableEquals(final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        assertOneListOfNullableEquals("OneListOfNullableDecimal mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfNullableEquals(final String message, final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfNullableEquals(final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        assertNullableListOfNullableEquals("NullableListOfNullableDecimal mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfOneEquals(final String message, final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        if (actuals.contains(null)) {
+            Assert.fail(message + "actuals contained a <null> element");
+        }
+
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        expectedsLoop: for (final java.math.BigDecimal expected : expecteds) {
+            if (actuals.contains(expected)) continue;
+            for (final java.math.BigDecimal actual : actuals) {
+                try {
+                    assertOneEquals(expected, actual);
+                    continue expectedsLoop;
+                }
+                catch (final AssertionError e) {}
+            }
+            Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+        }
+    }
+
+    private static void assertOneSetOfOneEquals(final String message, final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        if (expecteds.contains(null)) {
+            Assert.fail(message + "expecteds contained a <null> element - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfOneEquals(final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        assertOneSetOfOneEquals("OneSetOfOneDecimal mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfOneEquals(final String message, final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfOneEquals(final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        assertNullableSetOfOneEquals("NullableSetOfOneDecimal mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfNullableEquals(final String message, final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        expectedsLoop: for (final java.math.BigDecimal expected : expecteds) {
+            if (actuals.contains(expected)) continue;
+            for (final java.math.BigDecimal actual : actuals) {
+                try {
+                    assertNullableEquals(expected, actual);
+                    continue expectedsLoop;
+                }
+                catch (final AssertionError e) {}
+            }
+            Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+        }
+    }
+
+    private static void assertOneSetOfNullableEquals(final String message, final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfNullableEquals(final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        assertOneSetOfNullableEquals("OneSetOfNullableDecimal mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfNullableEquals(final String message, final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfNullableEquals(final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        assertNullableSetOfNullableEquals("NullableSetOfNullableDecimal mismatch: ", expecteds, actuals);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/DecimalWithScaleOf9Asserts.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/DecimalWithScaleOf9Asserts.java
@@ -1,0 +1,287 @@
+package com.dslplatform.ocd.javaasserts;
+
+import org.junit.Assert;
+
+public class DecimalWithScaleOf9Asserts {
+    static void assertSingleEquals(final String message, final java.math.BigDecimal expected, final java.math.BigDecimal actual) {
+        try {
+            expected.setScale(9);
+        }
+        catch (final ArithmeticException e) {
+            Assert.fail(message + "expected was a DecimalWithScaleOf9, but its scale was " + expected.scale() + " - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        }
+
+        try {
+            expected.setScale(9);
+        }
+        catch (final ArithmeticException e) {
+            Assert.fail(message + "actual was a DecimalWithScaleOf9, but its scale was " + actual.scale());
+        }
+
+        if (expected == actual || expected.compareTo(actual) == 0) return;
+        Assert.fail(message + "expected was \"" + expected + "\", but actual was \"" + actual + "\"");
+    }
+
+    static void assertOneEquals(final String message, final java.math.BigDecimal expected, final java.math.BigDecimal actual) {
+        if (expected == null) Assert.fail(message + "expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        if (expected == actual) return;
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertOneEquals(final java.math.BigDecimal expected, final java.math.BigDecimal actual) {
+        assertOneEquals("OneDecimalWithScaleOf9 mismatch: ", expected, actual);
+    }
+
+    private static void assertNullableEquals(final String message, final java.math.BigDecimal expected, final java.math.BigDecimal actual) {
+        if (expected == actual) return;
+        if (expected == null) Assert.fail(message + "expected was <null>, but actual was \"" + actual + "\"");
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertNullableEquals(final java.math.BigDecimal expected, final java.math.BigDecimal actual) {
+        assertNullableEquals("NullableDecimalWithScaleOf9 mismatch: ", expected, actual);
+    }
+
+    private static void assertArrayOfOneEquals(final String message, final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfOneEquals(final String message, final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        for (int i = 0; i < expecteds.length; i ++) {
+            if (expecteds[i] == null) {
+                Assert.fail(message + "expecteds contained a <null> element at index " + i + " - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+            }
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfOneEquals(final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        assertOneArrayOfOneEquals("OneArrayOfOneDecimalWithScaleOf9 mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfOneEquals(final String message, final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfOneEquals(final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        assertNullableArrayOfOneEquals("NullableArrayOfOneDecimalWithScaleOf9 mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertArrayOfNullableEquals(final String message, final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfNullableEquals(final String message, final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfNullableEquals(final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        assertOneArrayOfNullableEquals("OneArrayOfNullableDecimalWithScaleOf9 mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfNullableEquals(final String message, final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfNullableEquals(final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        assertNullableArrayOfNullableEquals("NullableArrayOfNullableDecimalWithScaleOf9 mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfOneEquals(final String message, final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<java.math.BigDecimal> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<java.math.BigDecimal> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final java.math.BigDecimal expected = expectedsIterator.next();
+            final java.math.BigDecimal actual = actualsIterator.next();
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfOneEquals(final String message, final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        int i = 0;
+        for (final java.math.BigDecimal expected : expecteds) {
+            if (expected == null) {
+                Assert.fail(message + "element mismatch occurred at index " + i + ": expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+            }
+            i++;
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfOneEquals(final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        assertOneListOfOneEquals("OneListOfOneDecimalWithScaleOf9 mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfOneEquals(final String message, final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfOneEquals(final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        assertNullableListOfOneEquals("NullableListOfOneDecimalWithScaleOf9 mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfNullableEquals(final String message, final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<java.math.BigDecimal> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<java.math.BigDecimal> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final java.math.BigDecimal expected = expectedsIterator.next();
+            final java.math.BigDecimal actual = actualsIterator.next();
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfNullableEquals(final String message, final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfNullableEquals(final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        assertOneListOfNullableEquals("OneListOfNullableDecimalWithScaleOf9 mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfNullableEquals(final String message, final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfNullableEquals(final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        assertNullableListOfNullableEquals("NullableListOfNullableDecimalWithScaleOf9 mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfOneEquals(final String message, final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        if (actuals.contains(null)) {
+            Assert.fail(message + "actuals contained a <null> element");
+        }
+
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        expectedsLoop: for (final java.math.BigDecimal expected : expecteds) {
+            if (actuals.contains(expected)) continue;
+            for (final java.math.BigDecimal actual : actuals) {
+                try {
+                    assertOneEquals(expected, actual);
+                    continue expectedsLoop;
+                }
+                catch (final AssertionError e) {}
+            }
+            Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+        }
+    }
+
+    private static void assertOneSetOfOneEquals(final String message, final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        if (expecteds.contains(null)) {
+            Assert.fail(message + "expecteds contained a <null> element - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfOneEquals(final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        assertOneSetOfOneEquals("OneSetOfOneDecimalWithScaleOf9 mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfOneEquals(final String message, final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfOneEquals(final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        assertNullableSetOfOneEquals("NullableSetOfOneDecimalWithScaleOf9 mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfNullableEquals(final String message, final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        expectedsLoop: for (final java.math.BigDecimal expected : expecteds) {
+            if (actuals.contains(expected)) continue;
+            for (final java.math.BigDecimal actual : actuals) {
+                try {
+                    assertNullableEquals(expected, actual);
+                    continue expectedsLoop;
+                }
+                catch (final AssertionError e) {}
+            }
+            Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+        }
+    }
+
+    private static void assertOneSetOfNullableEquals(final String message, final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfNullableEquals(final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        assertOneSetOfNullableEquals("OneSetOfNullableDecimalWithScaleOf9 mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfNullableEquals(final String message, final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfNullableEquals(final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        assertNullableSetOfNullableEquals("NullableSetOfNullableDecimalWithScaleOf9 mismatch: ", expecteds, actuals);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/DoubleAsserts.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/DoubleAsserts.java
@@ -1,0 +1,331 @@
+package com.dslplatform.ocd.javaasserts;
+
+import org.junit.Assert;
+
+public class DoubleAsserts {
+    static void assertSingleEquals(final String message, final double expected, final double actual, final int ulps) {
+        if (Double.doubleToRawLongBits(expected) == Double.doubleToRawLongBits(actual)) return;
+
+        if (ulps == 0) {
+            Assert.fail(message + "expected was \"" + expected + "\", but actual was \"" + actual + "\" - WARNING: You are comparing the bits of double values - not using an epsilon value!");
+        }
+
+        final double epsilon = Math.ulp(expected) * Math.abs(ulps);
+        if (expected >= actual - epsilon && expected <= actual + epsilon) return;
+        Assert.fail(message + "expected was \"" + expected + "\", but actual was \"" + actual + "\" (using epsilon value of \"" + epsilon + "\")");
+    }
+
+    static void assertOneEquals(final String message, final double expected, final double actual, final int ulps) {
+        assertSingleEquals(message, expected, actual, ulps);
+    }
+
+    public static void assertOneEquals(final double expected, final double actual, final int ulps) {
+        assertOneEquals("OneDouble mismatch: ", expected, actual, ulps);
+    }
+
+    public static void assertOneEquals(final double expected, final double actual) {
+        assertOneEquals(expected, actual, 0);
+    }
+
+    private static void assertNullableEquals(final String message, final Double expected, final Double actual, final int ulps) {
+        if (expected == actual) return;
+        if (expected == null) Assert.fail(message + "expected was <null>, but actual was \"" + actual + "\"");
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual, ulps);
+    }
+
+    public static void assertNullableEquals(final Double expected, final Double actual, final int ulps) {
+        assertNullableEquals("NullableDouble mismatch: ", expected, actual, ulps);
+    }
+
+    public static void assertNullableEquals(final Double expected, final Double actual) {
+        assertNullableEquals(expected, actual, 0);
+    }
+
+    private static void assertArrayOfOneEquals(final String message, final double[] expecteds, final double[] actuals, final int ulps) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i], ulps);
+        }
+    }
+
+    private static void assertOneArrayOfOneEquals(final String message, final double[] expecteds, final double[] actuals, final int ulps) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertOneArrayOfOneEquals(final double[] expecteds, final double[] actuals, final int ulps) {
+        assertOneArrayOfOneEquals("OneArrayOfOneDouble mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertOneArrayOfOneEquals(final double[] expecteds, final double[] actuals) {
+        assertOneArrayOfOneEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertNullableArrayOfOneEquals(final String message, final double[] expecteds, final double[] actuals, final int ulps) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableArrayOfOneEquals(final double[] expecteds, final double[] actuals, final int ulps) {
+        assertNullableArrayOfOneEquals("NullableArrayOfOneDouble mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableArrayOfOneEquals(final double[] expecteds, final double[] actuals) {
+        assertNullableArrayOfOneEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertArrayOfNullableEquals(final String message, final Double[] expecteds, final Double[] actuals, final int ulps) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i], ulps);
+        }
+    }
+
+    private static void assertOneArrayOfNullableEquals(final String message, final Double[] expecteds, final Double[] actuals, final int ulps) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertOneArrayOfNullableEquals(final Double[] expecteds, final Double[] actuals, final int ulps) {
+        assertOneArrayOfNullableEquals("OneArrayOfNullableDouble mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertOneArrayOfNullableEquals(final Double[] expecteds, final Double[] actuals) {
+        assertOneArrayOfNullableEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertNullableArrayOfNullableEquals(final String message, final Double[] expecteds, final Double[] actuals, final int ulps) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableArrayOfNullableEquals(final Double[] expecteds, final Double[] actuals, final int ulps) {
+        assertNullableArrayOfNullableEquals("NullableArrayOfNullableDouble mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableArrayOfNullableEquals(final Double[] expecteds, final Double[] actuals) {
+        assertNullableArrayOfNullableEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertListOfOneEquals(final String message, final java.util.List<Double> expecteds, final java.util.List<Double> actuals, final int ulps) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<Double> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<Double> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final Double expected = expectedsIterator.next();
+            final Double actual = actualsIterator.next();
+            if (actual == null) {
+                Assert.fail(message + "element mismatch occurred at index " + i + ": expected was \"" + expected + "\", but actual was <null>");
+            }
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expected.doubleValue(), actual.doubleValue(), ulps);
+        }
+    }
+
+    private static void assertOneListOfOneEquals(final String message, final java.util.List<Double> expecteds, final java.util.List<Double> actuals, final int ulps) {
+        int i = 0;
+        for (final Double expected : expecteds) {
+            if (expected == null) {
+                Assert.fail(message + "element mismatch occurred at index " + i + ": expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+            }
+            i++;
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertOneListOfOneEquals(final java.util.List<Double> expecteds, final java.util.List<Double> actuals, final int ulps) {
+        assertOneListOfOneEquals("OneListOfOneDouble mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertOneListOfOneEquals(final java.util.List<Double> expecteds, final java.util.List<Double> actuals) {
+        assertOneListOfOneEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertNullableListOfOneEquals(final String message, final java.util.List<Double> expecteds, final java.util.List<Double> actuals, final int ulps) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableListOfOneEquals(final java.util.List<Double> expecteds, final java.util.List<Double> actuals, final int ulps) {
+        assertNullableListOfOneEquals("NullableListOfOneDouble mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableListOfOneEquals(final java.util.List<Double> expecteds, final java.util.List<Double> actuals) {
+        assertNullableListOfOneEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertListOfNullableEquals(final String message, final java.util.List<Double> expecteds, final java.util.List<Double> actuals, final int ulps) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<Double> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<Double> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final Double expected = expectedsIterator.next();
+            final Double actual = actualsIterator.next();
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual, ulps);
+        }
+    }
+
+    private static void assertOneListOfNullableEquals(final String message, final java.util.List<Double> expecteds, final java.util.List<Double> actuals, final int ulps) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertOneListOfNullableEquals(final java.util.List<Double> expecteds, final java.util.List<Double> actuals, final int ulps) {
+        assertOneListOfNullableEquals("OneListOfNullableDouble mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertOneListOfNullableEquals(final java.util.List<Double> expecteds, final java.util.List<Double> actuals) {
+        assertOneListOfNullableEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertNullableListOfNullableEquals(final String message, final java.util.List<Double> expecteds, final java.util.List<Double> actuals, final int ulps) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableListOfNullableEquals(final java.util.List<Double> expecteds, final java.util.List<Double> actuals, final int ulps) {
+        assertNullableListOfNullableEquals("NullableListOfNullableDouble mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableListOfNullableEquals(final java.util.List<Double> expecteds, final java.util.List<Double> actuals) {
+        assertNullableListOfNullableEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertSetOfOneEquals(final String message, final java.util.Set<Double> expecteds, final java.util.Set<Double> actuals, final int ulps) {
+        if (actuals.contains(null)) {
+            Assert.fail(message + "actuals contained a <null> element");
+        }
+
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        expectedsLoop: for (final Double expected : expecteds) {
+            if (actuals.contains(expected)) continue;
+            for (final Double actual : actuals) {
+                try {
+                    assertOneEquals(expected.doubleValue(), actual.doubleValue(), ulps);
+                    continue expectedsLoop;
+                }
+                catch (final AssertionError e) {}
+            }
+            Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+        }
+    }
+
+    private static void assertOneSetOfOneEquals(final String message, final java.util.Set<Double> expecteds, final java.util.Set<Double> actuals, final int ulps) {
+        if (expecteds.contains(null)) {
+            Assert.fail(message + "expecteds contained a <null> element - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertOneSetOfOneEquals(final java.util.Set<Double> expecteds, final java.util.Set<Double> actuals, final int ulps) {
+        assertOneSetOfOneEquals("OneSetOfOneDouble mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertOneSetOfOneEquals(final java.util.Set<Double> expecteds, final java.util.Set<Double> actuals) {
+        assertOneSetOfOneEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertNullableSetOfOneEquals(final String message, final java.util.Set<Double> expecteds, final java.util.Set<Double> actuals, final int ulps) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableSetOfOneEquals(final java.util.Set<Double> expecteds, final java.util.Set<Double> actuals, final int ulps) {
+        assertNullableSetOfOneEquals("NullableSetOfOneDouble mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableSetOfOneEquals(final java.util.Set<Double> expecteds, final java.util.Set<Double> actuals) {
+        assertNullableSetOfOneEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertSetOfNullableEquals(final String message, final java.util.Set<Double> expecteds, final java.util.Set<Double> actuals, final int ulps) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        expectedsLoop: for (final Double expected : expecteds) {
+            if (actuals.contains(expected)) continue;
+            for (final Double actual : actuals) {
+                try {
+                    assertNullableEquals(expected, actual, ulps);
+                    continue expectedsLoop;
+                }
+                catch (final AssertionError e) {}
+            }
+            Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+        }
+    }
+
+    private static void assertOneSetOfNullableEquals(final String message, final java.util.Set<Double> expecteds, final java.util.Set<Double> actuals, final int ulps) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertOneSetOfNullableEquals(final java.util.Set<Double> expecteds, final java.util.Set<Double> actuals, final int ulps) {
+        assertOneSetOfNullableEquals("OneSetOfNullableDouble mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertOneSetOfNullableEquals(final java.util.Set<Double> expecteds, final java.util.Set<Double> actuals) {
+        assertOneSetOfNullableEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertNullableSetOfNullableEquals(final String message, final java.util.Set<Double> expecteds, final java.util.Set<Double> actuals, final int ulps) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableSetOfNullableEquals(final java.util.Set<Double> expecteds, final java.util.Set<Double> actuals, final int ulps) {
+        assertNullableSetOfNullableEquals("NullableSetOfNullableDouble mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableSetOfNullableEquals(final java.util.Set<Double> expecteds, final java.util.Set<Double> actuals) {
+        assertNullableSetOfNullableEquals(expecteds, actuals, 0);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/FloatAsserts.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/FloatAsserts.java
@@ -1,0 +1,331 @@
+package com.dslplatform.ocd.javaasserts;
+
+import org.junit.Assert;
+
+public class FloatAsserts {
+    static void assertSingleEquals(final String message, final float expected, final float actual, final int ulps) {
+        if (Float.floatToRawIntBits(expected) == Float.floatToRawIntBits(actual)) return;
+
+        if (ulps == 0) {
+            Assert.fail(message + "expected was \"" + expected + "\", but actual was \"" + actual + "\" - WARNING: You are comparing the bits of float values - not using an epsilon value!");
+        }
+
+        final float epsilon = Math.ulp(expected) * Math.abs(ulps);
+        if (expected >= actual - epsilon && expected <= actual + epsilon) return;
+        Assert.fail(message + "expected was \"" + expected + "\", but actual was \"" + actual + "\" (using epsilon value of \"" + epsilon + "\")");
+    }
+
+    static void assertOneEquals(final String message, final float expected, final float actual, final int ulps) {
+        assertSingleEquals(message, expected, actual, ulps);
+    }
+
+    public static void assertOneEquals(final float expected, final float actual, final int ulps) {
+        assertOneEquals("OneFloat mismatch: ", expected, actual, ulps);
+    }
+
+    public static void assertOneEquals(final float expected, final float actual) {
+        assertOneEquals(expected, actual, 0);
+    }
+
+    private static void assertNullableEquals(final String message, final Float expected, final Float actual, final int ulps) {
+        if (expected == actual) return;
+        if (expected == null) Assert.fail(message + "expected was <null>, but actual was \"" + actual + "\"");
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual, ulps);
+    }
+
+    public static void assertNullableEquals(final Float expected, final Float actual, final int ulps) {
+        assertNullableEquals("NullableFloat mismatch: ", expected, actual, ulps);
+    }
+
+    public static void assertNullableEquals(final Float expected, final Float actual) {
+        assertNullableEquals(expected, actual, 0);
+    }
+
+    private static void assertArrayOfOneEquals(final String message, final float[] expecteds, final float[] actuals, final int ulps) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i], ulps);
+        }
+    }
+
+    private static void assertOneArrayOfOneEquals(final String message, final float[] expecteds, final float[] actuals, final int ulps) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertOneArrayOfOneEquals(final float[] expecteds, final float[] actuals, final int ulps) {
+        assertOneArrayOfOneEquals("OneArrayOfOneFloat mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertOneArrayOfOneEquals(final float[] expecteds, final float[] actuals) {
+        assertOneArrayOfOneEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertNullableArrayOfOneEquals(final String message, final float[] expecteds, final float[] actuals, final int ulps) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableArrayOfOneEquals(final float[] expecteds, final float[] actuals, final int ulps) {
+        assertNullableArrayOfOneEquals("NullableArrayOfOneFloat mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableArrayOfOneEquals(final float[] expecteds, final float[] actuals) {
+        assertNullableArrayOfOneEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertArrayOfNullableEquals(final String message, final Float[] expecteds, final Float[] actuals, final int ulps) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i], ulps);
+        }
+    }
+
+    private static void assertOneArrayOfNullableEquals(final String message, final Float[] expecteds, final Float[] actuals, final int ulps) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertOneArrayOfNullableEquals(final Float[] expecteds, final Float[] actuals, final int ulps) {
+        assertOneArrayOfNullableEquals("OneArrayOfNullableFloat mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertOneArrayOfNullableEquals(final Float[] expecteds, final Float[] actuals) {
+        assertOneArrayOfNullableEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertNullableArrayOfNullableEquals(final String message, final Float[] expecteds, final Float[] actuals, final int ulps) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableArrayOfNullableEquals(final Float[] expecteds, final Float[] actuals, final int ulps) {
+        assertNullableArrayOfNullableEquals("NullableArrayOfNullableFloat mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableArrayOfNullableEquals(final Float[] expecteds, final Float[] actuals) {
+        assertNullableArrayOfNullableEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertListOfOneEquals(final String message, final java.util.List<Float> expecteds, final java.util.List<Float> actuals, final int ulps) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<Float> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<Float> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final Float expected = expectedsIterator.next();
+            final Float actual = actualsIterator.next();
+            if (actual == null) {
+                Assert.fail(message + "element mismatch occurred at index " + i + ": expected was \"" + expected + "\", but actual was <null>");
+            }
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expected.floatValue(), actual.floatValue(), ulps);
+        }
+    }
+
+    private static void assertOneListOfOneEquals(final String message, final java.util.List<Float> expecteds, final java.util.List<Float> actuals, final int ulps) {
+        int i = 0;
+        for (final Float expected : expecteds) {
+            if (expected == null) {
+                Assert.fail(message + "element mismatch occurred at index " + i + ": expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+            }
+            i++;
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertOneListOfOneEquals(final java.util.List<Float> expecteds, final java.util.List<Float> actuals, final int ulps) {
+        assertOneListOfOneEquals("OneListOfOneFloat mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertOneListOfOneEquals(final java.util.List<Float> expecteds, final java.util.List<Float> actuals) {
+        assertOneListOfOneEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertNullableListOfOneEquals(final String message, final java.util.List<Float> expecteds, final java.util.List<Float> actuals, final int ulps) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableListOfOneEquals(final java.util.List<Float> expecteds, final java.util.List<Float> actuals, final int ulps) {
+        assertNullableListOfOneEquals("NullableListOfOneFloat mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableListOfOneEquals(final java.util.List<Float> expecteds, final java.util.List<Float> actuals) {
+        assertNullableListOfOneEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertListOfNullableEquals(final String message, final java.util.List<Float> expecteds, final java.util.List<Float> actuals, final int ulps) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<Float> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<Float> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final Float expected = expectedsIterator.next();
+            final Float actual = actualsIterator.next();
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual, ulps);
+        }
+    }
+
+    private static void assertOneListOfNullableEquals(final String message, final java.util.List<Float> expecteds, final java.util.List<Float> actuals, final int ulps) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertOneListOfNullableEquals(final java.util.List<Float> expecteds, final java.util.List<Float> actuals, final int ulps) {
+        assertOneListOfNullableEquals("OneListOfNullableFloat mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertOneListOfNullableEquals(final java.util.List<Float> expecteds, final java.util.List<Float> actuals) {
+        assertOneListOfNullableEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertNullableListOfNullableEquals(final String message, final java.util.List<Float> expecteds, final java.util.List<Float> actuals, final int ulps) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableListOfNullableEquals(final java.util.List<Float> expecteds, final java.util.List<Float> actuals, final int ulps) {
+        assertNullableListOfNullableEquals("NullableListOfNullableFloat mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableListOfNullableEquals(final java.util.List<Float> expecteds, final java.util.List<Float> actuals) {
+        assertNullableListOfNullableEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertSetOfOneEquals(final String message, final java.util.Set<Float> expecteds, final java.util.Set<Float> actuals, final int ulps) {
+        if (actuals.contains(null)) {
+            Assert.fail(message + "actuals contained a <null> element");
+        }
+
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        expectedsLoop: for (final Float expected : expecteds) {
+            if (actuals.contains(expected)) continue;
+            for (final Float actual : actuals) {
+                try {
+                    assertOneEquals(expected.floatValue(), actual.floatValue(), ulps);
+                    continue expectedsLoop;
+                }
+                catch (final AssertionError e) {}
+            }
+            Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+        }
+    }
+
+    private static void assertOneSetOfOneEquals(final String message, final java.util.Set<Float> expecteds, final java.util.Set<Float> actuals, final int ulps) {
+        if (expecteds.contains(null)) {
+            Assert.fail(message + "expecteds contained a <null> element - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertOneSetOfOneEquals(final java.util.Set<Float> expecteds, final java.util.Set<Float> actuals, final int ulps) {
+        assertOneSetOfOneEquals("OneSetOfOneFloat mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertOneSetOfOneEquals(final java.util.Set<Float> expecteds, final java.util.Set<Float> actuals) {
+        assertOneSetOfOneEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertNullableSetOfOneEquals(final String message, final java.util.Set<Float> expecteds, final java.util.Set<Float> actuals, final int ulps) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableSetOfOneEquals(final java.util.Set<Float> expecteds, final java.util.Set<Float> actuals, final int ulps) {
+        assertNullableSetOfOneEquals("NullableSetOfOneFloat mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableSetOfOneEquals(final java.util.Set<Float> expecteds, final java.util.Set<Float> actuals) {
+        assertNullableSetOfOneEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertSetOfNullableEquals(final String message, final java.util.Set<Float> expecteds, final java.util.Set<Float> actuals, final int ulps) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        expectedsLoop: for (final Float expected : expecteds) {
+            if (actuals.contains(expected)) continue;
+            for (final Float actual : actuals) {
+                try {
+                    assertNullableEquals(expected, actual, ulps);
+                    continue expectedsLoop;
+                }
+                catch (final AssertionError e) {}
+            }
+            Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+        }
+    }
+
+    private static void assertOneSetOfNullableEquals(final String message, final java.util.Set<Float> expecteds, final java.util.Set<Float> actuals, final int ulps) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertOneSetOfNullableEquals(final java.util.Set<Float> expecteds, final java.util.Set<Float> actuals, final int ulps) {
+        assertOneSetOfNullableEquals("OneSetOfNullableFloat mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertOneSetOfNullableEquals(final java.util.Set<Float> expecteds, final java.util.Set<Float> actuals) {
+        assertOneSetOfNullableEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertNullableSetOfNullableEquals(final String message, final java.util.Set<Float> expecteds, final java.util.Set<Float> actuals, final int ulps) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableSetOfNullableEquals(final java.util.Set<Float> expecteds, final java.util.Set<Float> actuals, final int ulps) {
+        assertNullableSetOfNullableEquals("NullableSetOfNullableFloat mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableSetOfNullableEquals(final java.util.Set<Float> expecteds, final java.util.Set<Float> actuals) {
+        assertNullableSetOfNullableEquals(expecteds, actuals, 0);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/GuidAsserts.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/GuidAsserts.java
@@ -1,0 +1,261 @@
+package com.dslplatform.ocd.javaasserts;
+
+import org.junit.Assert;
+
+public class GuidAsserts {
+    static void assertSingleEquals(final String message, final java.util.UUID expected, final java.util.UUID actual) {
+        if (expected.equals(actual)) return;
+        Assert.fail(message + "expected was \"" + expected + "\", but actual was \"" + actual + "\"");
+    }
+
+    static void assertOneEquals(final String message, final java.util.UUID expected, final java.util.UUID actual) {
+        if (expected == null) Assert.fail(message + "expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        if (expected == actual) return;
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertOneEquals(final java.util.UUID expected, final java.util.UUID actual) {
+        assertOneEquals("OneGuid mismatch: ", expected, actual);
+    }
+
+    private static void assertNullableEquals(final String message, final java.util.UUID expected, final java.util.UUID actual) {
+        if (expected == actual) return;
+        if (expected == null) Assert.fail(message + "expected was <null>, but actual was \"" + actual + "\"");
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertNullableEquals(final java.util.UUID expected, final java.util.UUID actual) {
+        assertNullableEquals("NullableGuid mismatch: ", expected, actual);
+    }
+
+    private static void assertArrayOfOneEquals(final String message, final java.util.UUID[] expecteds, final java.util.UUID[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfOneEquals(final String message, final java.util.UUID[] expecteds, final java.util.UUID[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        for (int i = 0; i < expecteds.length; i ++) {
+            if (expecteds[i] == null) {
+                Assert.fail(message + "expecteds contained a <null> element at index " + i + " - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+            }
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfOneEquals(final java.util.UUID[] expecteds, final java.util.UUID[] actuals) {
+        assertOneArrayOfOneEquals("OneArrayOfOneGuid mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfOneEquals(final String message, final java.util.UUID[] expecteds, final java.util.UUID[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfOneEquals(final java.util.UUID[] expecteds, final java.util.UUID[] actuals) {
+        assertNullableArrayOfOneEquals("NullableArrayOfOneGuid mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertArrayOfNullableEquals(final String message, final java.util.UUID[] expecteds, final java.util.UUID[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfNullableEquals(final String message, final java.util.UUID[] expecteds, final java.util.UUID[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfNullableEquals(final java.util.UUID[] expecteds, final java.util.UUID[] actuals) {
+        assertOneArrayOfNullableEquals("OneArrayOfNullableGuid mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfNullableEquals(final String message, final java.util.UUID[] expecteds, final java.util.UUID[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfNullableEquals(final java.util.UUID[] expecteds, final java.util.UUID[] actuals) {
+        assertNullableArrayOfNullableEquals("NullableArrayOfNullableGuid mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfOneEquals(final String message, final java.util.List<java.util.UUID> expecteds, final java.util.List<java.util.UUID> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<java.util.UUID> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<java.util.UUID> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final java.util.UUID expected = expectedsIterator.next();
+            final java.util.UUID actual = actualsIterator.next();
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfOneEquals(final String message, final java.util.List<java.util.UUID> expecteds, final java.util.List<java.util.UUID> actuals) {
+        int i = 0;
+        for (final java.util.UUID expected : expecteds) {
+            if (expected == null) {
+                Assert.fail(message + "element mismatch occurred at index " + i + ": expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+            }
+            i++;
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfOneEquals(final java.util.List<java.util.UUID> expecteds, final java.util.List<java.util.UUID> actuals) {
+        assertOneListOfOneEquals("OneListOfOneGuid mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfOneEquals(final String message, final java.util.List<java.util.UUID> expecteds, final java.util.List<java.util.UUID> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfOneEquals(final java.util.List<java.util.UUID> expecteds, final java.util.List<java.util.UUID> actuals) {
+        assertNullableListOfOneEquals("NullableListOfOneGuid mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfNullableEquals(final String message, final java.util.List<java.util.UUID> expecteds, final java.util.List<java.util.UUID> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<java.util.UUID> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<java.util.UUID> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final java.util.UUID expected = expectedsIterator.next();
+            final java.util.UUID actual = actualsIterator.next();
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfNullableEquals(final String message, final java.util.List<java.util.UUID> expecteds, final java.util.List<java.util.UUID> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfNullableEquals(final java.util.List<java.util.UUID> expecteds, final java.util.List<java.util.UUID> actuals) {
+        assertOneListOfNullableEquals("OneListOfNullableGuid mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfNullableEquals(final String message, final java.util.List<java.util.UUID> expecteds, final java.util.List<java.util.UUID> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfNullableEquals(final java.util.List<java.util.UUID> expecteds, final java.util.List<java.util.UUID> actuals) {
+        assertNullableListOfNullableEquals("NullableListOfNullableGuid mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfOneEquals(final String message, final java.util.Set<java.util.UUID> expecteds, final java.util.Set<java.util.UUID> actuals) {
+        if (actuals.contains(null)) {
+            Assert.fail(message + "actuals contained a <null> element");
+        }
+
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        for (final java.util.UUID expected : expecteds) {
+            if (!actuals.contains(expected)) {
+                Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+            }
+        }
+    }
+
+    private static void assertOneSetOfOneEquals(final String message, final java.util.Set<java.util.UUID> expecteds, final java.util.Set<java.util.UUID> actuals) {
+        if (expecteds.contains(null)) {
+            Assert.fail(message + "expecteds contained a <null> element - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfOneEquals(final java.util.Set<java.util.UUID> expecteds, final java.util.Set<java.util.UUID> actuals) {
+        assertOneSetOfOneEquals("OneSetOfOneGuid mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfOneEquals(final String message, final java.util.Set<java.util.UUID> expecteds, final java.util.Set<java.util.UUID> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfOneEquals(final java.util.Set<java.util.UUID> expecteds, final java.util.Set<java.util.UUID> actuals) {
+        assertNullableSetOfOneEquals("NullableSetOfOneGuid mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfNullableEquals(final String message, final java.util.Set<java.util.UUID> expecteds, final java.util.Set<java.util.UUID> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        for (final java.util.UUID expected : expecteds) {
+            if (!actuals.contains(expected)) {
+                Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+            }
+        }
+    }
+
+    private static void assertOneSetOfNullableEquals(final String message, final java.util.Set<java.util.UUID> expecteds, final java.util.Set<java.util.UUID> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfNullableEquals(final java.util.Set<java.util.UUID> expecteds, final java.util.Set<java.util.UUID> actuals) {
+        assertOneSetOfNullableEquals("OneSetOfNullableGuid mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfNullableEquals(final String message, final java.util.Set<java.util.UUID> expecteds, final java.util.Set<java.util.UUID> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfNullableEquals(final java.util.Set<java.util.UUID> expecteds, final java.util.Set<java.util.UUID> actuals) {
+        assertNullableSetOfNullableEquals("NullableSetOfNullableGuid mismatch: ", expecteds, actuals);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/ImageAsserts.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/ImageAsserts.java
@@ -1,0 +1,279 @@
+package com.dslplatform.ocd.javaasserts;
+
+import org.junit.Assert;
+
+public class ImageAsserts {
+    static void assertSingleEquals(final String message, final java.awt.image.BufferedImage expected, final java.awt.image.BufferedImage actual) {
+        IntegerAsserts.assertSingleEquals(message + "comparing image width: ", expected.getWidth(), actual.getWidth());
+        IntegerAsserts.assertSingleEquals(message + "comparing image height: ", expected.getHeight(), actual.getHeight());
+
+        final int[] expectedRaster = expected.getRGB(0, 0, expected.getWidth(), expected.getHeight(), null, 0, expected.getWidth());
+        final int[] actualRaster = actual.getRGB(0, 0, actual.getWidth(), actual.getHeight(), null, 0, actual.getWidth());
+        if (java.util.Arrays.equals(expectedRaster, actualRaster)) return;
+
+        Assert.fail(message + "image dimensions were identical, but pixel values are different");
+    }
+
+    static void assertOneEquals(final String message, final java.awt.image.BufferedImage expected, final java.awt.image.BufferedImage actual) {
+        if (expected == null) Assert.fail(message + "expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        if (expected == actual) return;
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertOneEquals(final java.awt.image.BufferedImage expected, final java.awt.image.BufferedImage actual) {
+        assertOneEquals("OneImage mismatch: ", expected, actual);
+    }
+
+    private static void assertNullableEquals(final String message, final java.awt.image.BufferedImage expected, final java.awt.image.BufferedImage actual) {
+        if (expected == actual) return;
+        if (expected == null) Assert.fail(message + "expected was <null>, but actual was \"" + actual + "\"");
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertNullableEquals(final java.awt.image.BufferedImage expected, final java.awt.image.BufferedImage actual) {
+        assertNullableEquals("NullableImage mismatch: ", expected, actual);
+    }
+
+    private static void assertArrayOfOneEquals(final String message, final java.awt.image.BufferedImage[] expecteds, final java.awt.image.BufferedImage[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfOneEquals(final String message, final java.awt.image.BufferedImage[] expecteds, final java.awt.image.BufferedImage[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        for (int i = 0; i < expecteds.length; i ++) {
+            if (expecteds[i] == null) {
+                Assert.fail(message + "expecteds contained a <null> element at index " + i + " - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+            }
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfOneEquals(final java.awt.image.BufferedImage[] expecteds, final java.awt.image.BufferedImage[] actuals) {
+        assertOneArrayOfOneEquals("OneArrayOfOneImage mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfOneEquals(final String message, final java.awt.image.BufferedImage[] expecteds, final java.awt.image.BufferedImage[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfOneEquals(final java.awt.image.BufferedImage[] expecteds, final java.awt.image.BufferedImage[] actuals) {
+        assertNullableArrayOfOneEquals("NullableArrayOfOneImage mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertArrayOfNullableEquals(final String message, final java.awt.image.BufferedImage[] expecteds, final java.awt.image.BufferedImage[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfNullableEquals(final String message, final java.awt.image.BufferedImage[] expecteds, final java.awt.image.BufferedImage[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfNullableEquals(final java.awt.image.BufferedImage[] expecteds, final java.awt.image.BufferedImage[] actuals) {
+        assertOneArrayOfNullableEquals("OneArrayOfNullableImage mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfNullableEquals(final String message, final java.awt.image.BufferedImage[] expecteds, final java.awt.image.BufferedImage[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfNullableEquals(final java.awt.image.BufferedImage[] expecteds, final java.awt.image.BufferedImage[] actuals) {
+        assertNullableArrayOfNullableEquals("NullableArrayOfNullableImage mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfOneEquals(final String message, final java.util.List<java.awt.image.BufferedImage> expecteds, final java.util.List<java.awt.image.BufferedImage> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<java.awt.image.BufferedImage> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<java.awt.image.BufferedImage> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final java.awt.image.BufferedImage expected = expectedsIterator.next();
+            final java.awt.image.BufferedImage actual = actualsIterator.next();
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfOneEquals(final String message, final java.util.List<java.awt.image.BufferedImage> expecteds, final java.util.List<java.awt.image.BufferedImage> actuals) {
+        int i = 0;
+        for (final java.awt.image.BufferedImage expected : expecteds) {
+            if (expected == null) {
+                Assert.fail(message + "element mismatch occurred at index " + i + ": expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+            }
+            i++;
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfOneEquals(final java.util.List<java.awt.image.BufferedImage> expecteds, final java.util.List<java.awt.image.BufferedImage> actuals) {
+        assertOneListOfOneEquals("OneListOfOneImage mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfOneEquals(final String message, final java.util.List<java.awt.image.BufferedImage> expecteds, final java.util.List<java.awt.image.BufferedImage> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfOneEquals(final java.util.List<java.awt.image.BufferedImage> expecteds, final java.util.List<java.awt.image.BufferedImage> actuals) {
+        assertNullableListOfOneEquals("NullableListOfOneImage mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfNullableEquals(final String message, final java.util.List<java.awt.image.BufferedImage> expecteds, final java.util.List<java.awt.image.BufferedImage> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<java.awt.image.BufferedImage> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<java.awt.image.BufferedImage> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final java.awt.image.BufferedImage expected = expectedsIterator.next();
+            final java.awt.image.BufferedImage actual = actualsIterator.next();
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfNullableEquals(final String message, final java.util.List<java.awt.image.BufferedImage> expecteds, final java.util.List<java.awt.image.BufferedImage> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfNullableEquals(final java.util.List<java.awt.image.BufferedImage> expecteds, final java.util.List<java.awt.image.BufferedImage> actuals) {
+        assertOneListOfNullableEquals("OneListOfNullableImage mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfNullableEquals(final String message, final java.util.List<java.awt.image.BufferedImage> expecteds, final java.util.List<java.awt.image.BufferedImage> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfNullableEquals(final java.util.List<java.awt.image.BufferedImage> expecteds, final java.util.List<java.awt.image.BufferedImage> actuals) {
+        assertNullableListOfNullableEquals("NullableListOfNullableImage mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfOneEquals(final String message, final java.util.Set<java.awt.image.BufferedImage> expecteds, final java.util.Set<java.awt.image.BufferedImage> actuals) {
+        if (actuals.contains(null)) {
+            Assert.fail(message + "actuals contained a <null> element");
+        }
+
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        expectedsLoop: for (final java.awt.image.BufferedImage expected : expecteds) {
+            if (actuals.contains(expected)) continue;
+            for (final java.awt.image.BufferedImage actual : actuals) {
+                try {
+                    assertOneEquals(expected, actual);
+                    continue expectedsLoop;
+                }
+                catch (final AssertionError e) {}
+            }
+            Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+        }
+    }
+
+    private static void assertOneSetOfOneEquals(final String message, final java.util.Set<java.awt.image.BufferedImage> expecteds, final java.util.Set<java.awt.image.BufferedImage> actuals) {
+        if (expecteds.contains(null)) {
+            Assert.fail(message + "expecteds contained a <null> element - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfOneEquals(final java.util.Set<java.awt.image.BufferedImage> expecteds, final java.util.Set<java.awt.image.BufferedImage> actuals) {
+        assertOneSetOfOneEquals("OneSetOfOneImage mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfOneEquals(final String message, final java.util.Set<java.awt.image.BufferedImage> expecteds, final java.util.Set<java.awt.image.BufferedImage> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfOneEquals(final java.util.Set<java.awt.image.BufferedImage> expecteds, final java.util.Set<java.awt.image.BufferedImage> actuals) {
+        assertNullableSetOfOneEquals("NullableSetOfOneImage mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfNullableEquals(final String message, final java.util.Set<java.awt.image.BufferedImage> expecteds, final java.util.Set<java.awt.image.BufferedImage> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        expectedsLoop: for (final java.awt.image.BufferedImage expected : expecteds) {
+            if (actuals.contains(expected)) continue;
+            for (final java.awt.image.BufferedImage actual : actuals) {
+                try {
+                    assertNullableEquals(expected, actual);
+                    continue expectedsLoop;
+                }
+                catch (final AssertionError e) {}
+            }
+            Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+        }
+    }
+
+    private static void assertOneSetOfNullableEquals(final String message, final java.util.Set<java.awt.image.BufferedImage> expecteds, final java.util.Set<java.awt.image.BufferedImage> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfNullableEquals(final java.util.Set<java.awt.image.BufferedImage> expecteds, final java.util.Set<java.awt.image.BufferedImage> actuals) {
+        assertOneSetOfNullableEquals("OneSetOfNullableImage mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfNullableEquals(final String message, final java.util.Set<java.awt.image.BufferedImage> expecteds, final java.util.Set<java.awt.image.BufferedImage> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfNullableEquals(final java.util.Set<java.awt.image.BufferedImage> expecteds, final java.util.Set<java.awt.image.BufferedImage> actuals) {
+        assertNullableSetOfNullableEquals("NullableSetOfNullableImage mismatch: ", expecteds, actuals);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/IntegerAsserts.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/IntegerAsserts.java
@@ -1,0 +1,256 @@
+package com.dslplatform.ocd.javaasserts;
+
+import org.junit.Assert;
+
+public class IntegerAsserts {
+    static void assertSingleEquals(final String message, final int expected, final int actual) {
+        if (expected == actual) return;
+        Assert.fail(message + "expected was \"" + expected + "\", but actual was \"" + actual + "\"");
+    }
+
+    static void assertOneEquals(final String message, final int expected, final int actual) {
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertOneEquals(final int expected, final int actual) {
+        assertOneEquals("OneInteger mismatch: ", expected, actual);
+    }
+
+    private static void assertNullableEquals(final String message, final Integer expected, final Integer actual) {
+        if (expected == actual) return;
+        if (expected == null) Assert.fail(message + "expected was <null>, but actual was \"" + actual + "\"");
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertNullableEquals(final Integer expected, final Integer actual) {
+        assertNullableEquals("NullableInteger mismatch: ", expected, actual);
+    }
+
+    private static void assertArrayOfOneEquals(final String message, final int[] expecteds, final int[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfOneEquals(final String message, final int[] expecteds, final int[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfOneEquals(final int[] expecteds, final int[] actuals) {
+        assertOneArrayOfOneEquals("OneArrayOfOneInteger mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfOneEquals(final String message, final int[] expecteds, final int[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfOneEquals(final int[] expecteds, final int[] actuals) {
+        assertNullableArrayOfOneEquals("NullableArrayOfOneInteger mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertArrayOfNullableEquals(final String message, final Integer[] expecteds, final Integer[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfNullableEquals(final String message, final Integer[] expecteds, final Integer[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfNullableEquals(final Integer[] expecteds, final Integer[] actuals) {
+        assertOneArrayOfNullableEquals("OneArrayOfNullableInteger mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfNullableEquals(final String message, final Integer[] expecteds, final Integer[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfNullableEquals(final Integer[] expecteds, final Integer[] actuals) {
+        assertNullableArrayOfNullableEquals("NullableArrayOfNullableInteger mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfOneEquals(final String message, final java.util.List<Integer> expecteds, final java.util.List<Integer> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<Integer> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<Integer> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final Integer expected = expectedsIterator.next();
+            final Integer actual = actualsIterator.next();
+            if (actual == null) {
+                Assert.fail(message + "element mismatch occurred at index " + i + ": expected was \"" + expected + "\", but actual was <null>");
+            }
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expected.intValue(), actual.intValue());
+        }
+    }
+
+    private static void assertOneListOfOneEquals(final String message, final java.util.List<Integer> expecteds, final java.util.List<Integer> actuals) {
+        int i = 0;
+        for (final Integer expected : expecteds) {
+            if (expected == null) {
+                Assert.fail(message + "element mismatch occurred at index " + i + ": expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+            }
+            i++;
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfOneEquals(final java.util.List<Integer> expecteds, final java.util.List<Integer> actuals) {
+        assertOneListOfOneEquals("OneListOfOneInteger mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfOneEquals(final String message, final java.util.List<Integer> expecteds, final java.util.List<Integer> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfOneEquals(final java.util.List<Integer> expecteds, final java.util.List<Integer> actuals) {
+        assertNullableListOfOneEquals("NullableListOfOneInteger mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfNullableEquals(final String message, final java.util.List<Integer> expecteds, final java.util.List<Integer> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<Integer> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<Integer> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final Integer expected = expectedsIterator.next();
+            final Integer actual = actualsIterator.next();
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfNullableEquals(final String message, final java.util.List<Integer> expecteds, final java.util.List<Integer> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfNullableEquals(final java.util.List<Integer> expecteds, final java.util.List<Integer> actuals) {
+        assertOneListOfNullableEquals("OneListOfNullableInteger mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfNullableEquals(final String message, final java.util.List<Integer> expecteds, final java.util.List<Integer> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfNullableEquals(final java.util.List<Integer> expecteds, final java.util.List<Integer> actuals) {
+        assertNullableListOfNullableEquals("NullableListOfNullableInteger mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfOneEquals(final String message, final java.util.Set<Integer> expecteds, final java.util.Set<Integer> actuals) {
+        if (actuals.contains(null)) {
+            Assert.fail(message + "actuals contained a <null> element");
+        }
+
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        for (final Integer expected : expecteds) {
+            if (!actuals.contains(expected)) {
+                Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+            }
+        }
+    }
+
+    private static void assertOneSetOfOneEquals(final String message, final java.util.Set<Integer> expecteds, final java.util.Set<Integer> actuals) {
+        if (expecteds.contains(null)) {
+            Assert.fail(message + "expecteds contained a <null> element - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfOneEquals(final java.util.Set<Integer> expecteds, final java.util.Set<Integer> actuals) {
+        assertOneSetOfOneEquals("OneSetOfOneInteger mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfOneEquals(final String message, final java.util.Set<Integer> expecteds, final java.util.Set<Integer> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfOneEquals(final java.util.Set<Integer> expecteds, final java.util.Set<Integer> actuals) {
+        assertNullableSetOfOneEquals("NullableSetOfOneInteger mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfNullableEquals(final String message, final java.util.Set<Integer> expecteds, final java.util.Set<Integer> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        for (final Integer expected : expecteds) {
+            if (!actuals.contains(expected)) {
+                Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+            }
+        }
+    }
+
+    private static void assertOneSetOfNullableEquals(final String message, final java.util.Set<Integer> expecteds, final java.util.Set<Integer> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfNullableEquals(final java.util.Set<Integer> expecteds, final java.util.Set<Integer> actuals) {
+        assertOneSetOfNullableEquals("OneSetOfNullableInteger mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfNullableEquals(final String message, final java.util.Set<Integer> expecteds, final java.util.Set<Integer> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfNullableEquals(final java.util.Set<Integer> expecteds, final java.util.Set<Integer> actuals) {
+        assertNullableSetOfNullableEquals("NullableSetOfNullableInteger mismatch: ", expecteds, actuals);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/IpAsserts.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/IpAsserts.java
@@ -1,0 +1,261 @@
+package com.dslplatform.ocd.javaasserts;
+
+import org.junit.Assert;
+
+public class IpAsserts {
+    static void assertSingleEquals(final String message, final java.net.InetAddress expected, final java.net.InetAddress actual) {
+        if (expected.equals(actual)) return;
+        Assert.fail(message + "expected was \"" + expected + "\", but actual was \"" + actual + "\"");
+    }
+
+    static void assertOneEquals(final String message, final java.net.InetAddress expected, final java.net.InetAddress actual) {
+        if (expected == null) Assert.fail(message + "expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        if (expected == actual) return;
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertOneEquals(final java.net.InetAddress expected, final java.net.InetAddress actual) {
+        assertOneEquals("OneIp mismatch: ", expected, actual);
+    }
+
+    private static void assertNullableEquals(final String message, final java.net.InetAddress expected, final java.net.InetAddress actual) {
+        if (expected == actual) return;
+        if (expected == null) Assert.fail(message + "expected was <null>, but actual was \"" + actual + "\"");
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertNullableEquals(final java.net.InetAddress expected, final java.net.InetAddress actual) {
+        assertNullableEquals("NullableIp mismatch: ", expected, actual);
+    }
+
+    private static void assertArrayOfOneEquals(final String message, final java.net.InetAddress[] expecteds, final java.net.InetAddress[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfOneEquals(final String message, final java.net.InetAddress[] expecteds, final java.net.InetAddress[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        for (int i = 0; i < expecteds.length; i ++) {
+            if (expecteds[i] == null) {
+                Assert.fail(message + "expecteds contained a <null> element at index " + i + " - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+            }
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfOneEquals(final java.net.InetAddress[] expecteds, final java.net.InetAddress[] actuals) {
+        assertOneArrayOfOneEquals("OneArrayOfOneIp mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfOneEquals(final String message, final java.net.InetAddress[] expecteds, final java.net.InetAddress[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfOneEquals(final java.net.InetAddress[] expecteds, final java.net.InetAddress[] actuals) {
+        assertNullableArrayOfOneEquals("NullableArrayOfOneIp mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertArrayOfNullableEquals(final String message, final java.net.InetAddress[] expecteds, final java.net.InetAddress[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfNullableEquals(final String message, final java.net.InetAddress[] expecteds, final java.net.InetAddress[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfNullableEquals(final java.net.InetAddress[] expecteds, final java.net.InetAddress[] actuals) {
+        assertOneArrayOfNullableEquals("OneArrayOfNullableIp mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfNullableEquals(final String message, final java.net.InetAddress[] expecteds, final java.net.InetAddress[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfNullableEquals(final java.net.InetAddress[] expecteds, final java.net.InetAddress[] actuals) {
+        assertNullableArrayOfNullableEquals("NullableArrayOfNullableIp mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfOneEquals(final String message, final java.util.List<java.net.InetAddress> expecteds, final java.util.List<java.net.InetAddress> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<java.net.InetAddress> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<java.net.InetAddress> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final java.net.InetAddress expected = expectedsIterator.next();
+            final java.net.InetAddress actual = actualsIterator.next();
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfOneEquals(final String message, final java.util.List<java.net.InetAddress> expecteds, final java.util.List<java.net.InetAddress> actuals) {
+        int i = 0;
+        for (final java.net.InetAddress expected : expecteds) {
+            if (expected == null) {
+                Assert.fail(message + "element mismatch occurred at index " + i + ": expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+            }
+            i++;
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfOneEquals(final java.util.List<java.net.InetAddress> expecteds, final java.util.List<java.net.InetAddress> actuals) {
+        assertOneListOfOneEquals("OneListOfOneIp mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfOneEquals(final String message, final java.util.List<java.net.InetAddress> expecteds, final java.util.List<java.net.InetAddress> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfOneEquals(final java.util.List<java.net.InetAddress> expecteds, final java.util.List<java.net.InetAddress> actuals) {
+        assertNullableListOfOneEquals("NullableListOfOneIp mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfNullableEquals(final String message, final java.util.List<java.net.InetAddress> expecteds, final java.util.List<java.net.InetAddress> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<java.net.InetAddress> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<java.net.InetAddress> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final java.net.InetAddress expected = expectedsIterator.next();
+            final java.net.InetAddress actual = actualsIterator.next();
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfNullableEquals(final String message, final java.util.List<java.net.InetAddress> expecteds, final java.util.List<java.net.InetAddress> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfNullableEquals(final java.util.List<java.net.InetAddress> expecteds, final java.util.List<java.net.InetAddress> actuals) {
+        assertOneListOfNullableEquals("OneListOfNullableIp mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfNullableEquals(final String message, final java.util.List<java.net.InetAddress> expecteds, final java.util.List<java.net.InetAddress> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfNullableEquals(final java.util.List<java.net.InetAddress> expecteds, final java.util.List<java.net.InetAddress> actuals) {
+        assertNullableListOfNullableEquals("NullableListOfNullableIp mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfOneEquals(final String message, final java.util.Set<java.net.InetAddress> expecteds, final java.util.Set<java.net.InetAddress> actuals) {
+        if (actuals.contains(null)) {
+            Assert.fail(message + "actuals contained a <null> element");
+        }
+
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        for (final java.net.InetAddress expected : expecteds) {
+            if (!actuals.contains(expected)) {
+                Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+            }
+        }
+    }
+
+    private static void assertOneSetOfOneEquals(final String message, final java.util.Set<java.net.InetAddress> expecteds, final java.util.Set<java.net.InetAddress> actuals) {
+        if (expecteds.contains(null)) {
+            Assert.fail(message + "expecteds contained a <null> element - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfOneEquals(final java.util.Set<java.net.InetAddress> expecteds, final java.util.Set<java.net.InetAddress> actuals) {
+        assertOneSetOfOneEquals("OneSetOfOneIp mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfOneEquals(final String message, final java.util.Set<java.net.InetAddress> expecteds, final java.util.Set<java.net.InetAddress> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfOneEquals(final java.util.Set<java.net.InetAddress> expecteds, final java.util.Set<java.net.InetAddress> actuals) {
+        assertNullableSetOfOneEquals("NullableSetOfOneIp mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfNullableEquals(final String message, final java.util.Set<java.net.InetAddress> expecteds, final java.util.Set<java.net.InetAddress> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        for (final java.net.InetAddress expected : expecteds) {
+            if (!actuals.contains(expected)) {
+                Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+            }
+        }
+    }
+
+    private static void assertOneSetOfNullableEquals(final String message, final java.util.Set<java.net.InetAddress> expecteds, final java.util.Set<java.net.InetAddress> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfNullableEquals(final java.util.Set<java.net.InetAddress> expecteds, final java.util.Set<java.net.InetAddress> actuals) {
+        assertOneSetOfNullableEquals("OneSetOfNullableIp mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfNullableEquals(final String message, final java.util.Set<java.net.InetAddress> expecteds, final java.util.Set<java.net.InetAddress> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfNullableEquals(final java.util.Set<java.net.InetAddress> expecteds, final java.util.Set<java.net.InetAddress> actuals) {
+        assertNullableSetOfNullableEquals("NullableSetOfNullableIp mismatch: ", expecteds, actuals);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/LocationAsserts.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/LocationAsserts.java
@@ -1,0 +1,329 @@
+package com.dslplatform.ocd.javaasserts;
+
+import org.junit.Assert;
+
+public class LocationAsserts {
+    static void assertSingleEquals(final String message, final java.awt.geom.Point2D expected, final java.awt.geom.Point2D actual, final int ulps) {
+        FloatAsserts.assertOneEquals(message + ": comparing X coordinate: ", (float) expected.getX(), (float) actual.getX(), ulps);
+        FloatAsserts.assertOneEquals(message + ": comparing Y coordinate: ", (float) expected.getY(), (float) actual.getY(), ulps);
+    }
+
+    static void assertOneEquals(final String message, final java.awt.geom.Point2D expected, final java.awt.geom.Point2D actual, final int ulps) {
+        if (expected == null) Assert.fail(message + "expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        if (expected == actual) return;
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual, ulps);
+    }
+
+    public static void assertOneEquals(final java.awt.geom.Point2D expected, final java.awt.geom.Point2D actual, final int ulps) {
+        assertOneEquals("OneLocation mismatch: ", expected, actual, ulps);
+    }
+
+    public static void assertOneEquals(final java.awt.geom.Point2D expected, final java.awt.geom.Point2D actual) {
+        assertOneEquals(expected, actual, 0);
+    }
+
+    private static void assertNullableEquals(final String message, final java.awt.geom.Point2D expected, final java.awt.geom.Point2D actual, final int ulps) {
+        if (expected == actual) return;
+        if (expected == null) Assert.fail(message + "expected was <null>, but actual was \"" + actual + "\"");
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual, ulps);
+    }
+
+    public static void assertNullableEquals(final java.awt.geom.Point2D expected, final java.awt.geom.Point2D actual, final int ulps) {
+        assertNullableEquals("NullableLocation mismatch: ", expected, actual, ulps);
+    }
+
+    public static void assertNullableEquals(final java.awt.geom.Point2D expected, final java.awt.geom.Point2D actual) {
+        assertNullableEquals(expected, actual, 0);
+    }
+
+    private static void assertArrayOfOneEquals(final String message, final java.awt.geom.Point2D[] expecteds, final java.awt.geom.Point2D[] actuals, final int ulps) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i], ulps);
+        }
+    }
+
+    private static void assertOneArrayOfOneEquals(final String message, final java.awt.geom.Point2D[] expecteds, final java.awt.geom.Point2D[] actuals, final int ulps) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        for (int i = 0; i < expecteds.length; i ++) {
+            if (expecteds[i] == null) {
+                Assert.fail(message + "expecteds contained a <null> element at index " + i + " - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+            }
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertOneArrayOfOneEquals(final java.awt.geom.Point2D[] expecteds, final java.awt.geom.Point2D[] actuals, final int ulps) {
+        assertOneArrayOfOneEquals("OneArrayOfOneLocation mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertOneArrayOfOneEquals(final java.awt.geom.Point2D[] expecteds, final java.awt.geom.Point2D[] actuals) {
+        assertOneArrayOfOneEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertNullableArrayOfOneEquals(final String message, final java.awt.geom.Point2D[] expecteds, final java.awt.geom.Point2D[] actuals, final int ulps) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableArrayOfOneEquals(final java.awt.geom.Point2D[] expecteds, final java.awt.geom.Point2D[] actuals, final int ulps) {
+        assertNullableArrayOfOneEquals("NullableArrayOfOneLocation mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableArrayOfOneEquals(final java.awt.geom.Point2D[] expecteds, final java.awt.geom.Point2D[] actuals) {
+        assertNullableArrayOfOneEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertArrayOfNullableEquals(final String message, final java.awt.geom.Point2D[] expecteds, final java.awt.geom.Point2D[] actuals, final int ulps) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i], ulps);
+        }
+    }
+
+    private static void assertOneArrayOfNullableEquals(final String message, final java.awt.geom.Point2D[] expecteds, final java.awt.geom.Point2D[] actuals, final int ulps) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertOneArrayOfNullableEquals(final java.awt.geom.Point2D[] expecteds, final java.awt.geom.Point2D[] actuals, final int ulps) {
+        assertOneArrayOfNullableEquals("OneArrayOfNullableLocation mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertOneArrayOfNullableEquals(final java.awt.geom.Point2D[] expecteds, final java.awt.geom.Point2D[] actuals) {
+        assertOneArrayOfNullableEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertNullableArrayOfNullableEquals(final String message, final java.awt.geom.Point2D[] expecteds, final java.awt.geom.Point2D[] actuals, final int ulps) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableArrayOfNullableEquals(final java.awt.geom.Point2D[] expecteds, final java.awt.geom.Point2D[] actuals, final int ulps) {
+        assertNullableArrayOfNullableEquals("NullableArrayOfNullableLocation mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableArrayOfNullableEquals(final java.awt.geom.Point2D[] expecteds, final java.awt.geom.Point2D[] actuals) {
+        assertNullableArrayOfNullableEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertListOfOneEquals(final String message, final java.util.List<java.awt.geom.Point2D> expecteds, final java.util.List<java.awt.geom.Point2D> actuals, final int ulps) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<java.awt.geom.Point2D> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<java.awt.geom.Point2D> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final java.awt.geom.Point2D expected = expectedsIterator.next();
+            final java.awt.geom.Point2D actual = actualsIterator.next();
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual, ulps);
+        }
+    }
+
+    private static void assertOneListOfOneEquals(final String message, final java.util.List<java.awt.geom.Point2D> expecteds, final java.util.List<java.awt.geom.Point2D> actuals, final int ulps) {
+        int i = 0;
+        for (final java.awt.geom.Point2D expected : expecteds) {
+            if (expected == null) {
+                Assert.fail(message + "element mismatch occurred at index " + i + ": expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+            }
+            i++;
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertOneListOfOneEquals(final java.util.List<java.awt.geom.Point2D> expecteds, final java.util.List<java.awt.geom.Point2D> actuals, final int ulps) {
+        assertOneListOfOneEquals("OneListOfOneLocation mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertOneListOfOneEquals(final java.util.List<java.awt.geom.Point2D> expecteds, final java.util.List<java.awt.geom.Point2D> actuals) {
+        assertOneListOfOneEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertNullableListOfOneEquals(final String message, final java.util.List<java.awt.geom.Point2D> expecteds, final java.util.List<java.awt.geom.Point2D> actuals, final int ulps) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableListOfOneEquals(final java.util.List<java.awt.geom.Point2D> expecteds, final java.util.List<java.awt.geom.Point2D> actuals, final int ulps) {
+        assertNullableListOfOneEquals("NullableListOfOneLocation mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableListOfOneEquals(final java.util.List<java.awt.geom.Point2D> expecteds, final java.util.List<java.awt.geom.Point2D> actuals) {
+        assertNullableListOfOneEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertListOfNullableEquals(final String message, final java.util.List<java.awt.geom.Point2D> expecteds, final java.util.List<java.awt.geom.Point2D> actuals, final int ulps) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<java.awt.geom.Point2D> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<java.awt.geom.Point2D> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final java.awt.geom.Point2D expected = expectedsIterator.next();
+            final java.awt.geom.Point2D actual = actualsIterator.next();
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual, ulps);
+        }
+    }
+
+    private static void assertOneListOfNullableEquals(final String message, final java.util.List<java.awt.geom.Point2D> expecteds, final java.util.List<java.awt.geom.Point2D> actuals, final int ulps) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertOneListOfNullableEquals(final java.util.List<java.awt.geom.Point2D> expecteds, final java.util.List<java.awt.geom.Point2D> actuals, final int ulps) {
+        assertOneListOfNullableEquals("OneListOfNullableLocation mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertOneListOfNullableEquals(final java.util.List<java.awt.geom.Point2D> expecteds, final java.util.List<java.awt.geom.Point2D> actuals) {
+        assertOneListOfNullableEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertNullableListOfNullableEquals(final String message, final java.util.List<java.awt.geom.Point2D> expecteds, final java.util.List<java.awt.geom.Point2D> actuals, final int ulps) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableListOfNullableEquals(final java.util.List<java.awt.geom.Point2D> expecteds, final java.util.List<java.awt.geom.Point2D> actuals, final int ulps) {
+        assertNullableListOfNullableEquals("NullableListOfNullableLocation mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableListOfNullableEquals(final java.util.List<java.awt.geom.Point2D> expecteds, final java.util.List<java.awt.geom.Point2D> actuals) {
+        assertNullableListOfNullableEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertSetOfOneEquals(final String message, final java.util.Set<java.awt.geom.Point2D> expecteds, final java.util.Set<java.awt.geom.Point2D> actuals, final int ulps) {
+        if (actuals.contains(null)) {
+            Assert.fail(message + "actuals contained a <null> element");
+        }
+
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        expectedsLoop: for (final java.awt.geom.Point2D expected : expecteds) {
+            if (actuals.contains(expected)) continue;
+            for (final java.awt.geom.Point2D actual : actuals) {
+                try {
+                    assertOneEquals(expected, actual, ulps);
+                    continue expectedsLoop;
+                }
+                catch (final AssertionError e) {}
+            }
+            Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+        }
+    }
+
+    private static void assertOneSetOfOneEquals(final String message, final java.util.Set<java.awt.geom.Point2D> expecteds, final java.util.Set<java.awt.geom.Point2D> actuals, final int ulps) {
+        if (expecteds.contains(null)) {
+            Assert.fail(message + "expecteds contained a <null> element - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertOneSetOfOneEquals(final java.util.Set<java.awt.geom.Point2D> expecteds, final java.util.Set<java.awt.geom.Point2D> actuals, final int ulps) {
+        assertOneSetOfOneEquals("OneSetOfOneLocation mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertOneSetOfOneEquals(final java.util.Set<java.awt.geom.Point2D> expecteds, final java.util.Set<java.awt.geom.Point2D> actuals) {
+        assertOneSetOfOneEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertNullableSetOfOneEquals(final String message, final java.util.Set<java.awt.geom.Point2D> expecteds, final java.util.Set<java.awt.geom.Point2D> actuals, final int ulps) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableSetOfOneEquals(final java.util.Set<java.awt.geom.Point2D> expecteds, final java.util.Set<java.awt.geom.Point2D> actuals, final int ulps) {
+        assertNullableSetOfOneEquals("NullableSetOfOneLocation mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableSetOfOneEquals(final java.util.Set<java.awt.geom.Point2D> expecteds, final java.util.Set<java.awt.geom.Point2D> actuals) {
+        assertNullableSetOfOneEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertSetOfNullableEquals(final String message, final java.util.Set<java.awt.geom.Point2D> expecteds, final java.util.Set<java.awt.geom.Point2D> actuals, final int ulps) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        expectedsLoop: for (final java.awt.geom.Point2D expected : expecteds) {
+            if (actuals.contains(expected)) continue;
+            for (final java.awt.geom.Point2D actual : actuals) {
+                try {
+                    assertNullableEquals(expected, actual, ulps);
+                    continue expectedsLoop;
+                }
+                catch (final AssertionError e) {}
+            }
+            Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+        }
+    }
+
+    private static void assertOneSetOfNullableEquals(final String message, final java.util.Set<java.awt.geom.Point2D> expecteds, final java.util.Set<java.awt.geom.Point2D> actuals, final int ulps) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertOneSetOfNullableEquals(final java.util.Set<java.awt.geom.Point2D> expecteds, final java.util.Set<java.awt.geom.Point2D> actuals, final int ulps) {
+        assertOneSetOfNullableEquals("OneSetOfNullableLocation mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertOneSetOfNullableEquals(final java.util.Set<java.awt.geom.Point2D> expecteds, final java.util.Set<java.awt.geom.Point2D> actuals) {
+        assertOneSetOfNullableEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertNullableSetOfNullableEquals(final String message, final java.util.Set<java.awt.geom.Point2D> expecteds, final java.util.Set<java.awt.geom.Point2D> actuals, final int ulps) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableSetOfNullableEquals(final java.util.Set<java.awt.geom.Point2D> expecteds, final java.util.Set<java.awt.geom.Point2D> actuals, final int ulps) {
+        assertNullableSetOfNullableEquals("NullableSetOfNullableLocation mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableSetOfNullableEquals(final java.util.Set<java.awt.geom.Point2D> expecteds, final java.util.Set<java.awt.geom.Point2D> actuals) {
+        assertNullableSetOfNullableEquals(expecteds, actuals, 0);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/LongAsserts.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/LongAsserts.java
@@ -1,0 +1,256 @@
+package com.dslplatform.ocd.javaasserts;
+
+import org.junit.Assert;
+
+public class LongAsserts {
+    static void assertSingleEquals(final String message, final long expected, final long actual) {
+        if (expected == actual) return;
+        Assert.fail(message + "expected was \"" + expected + "\", but actual was \"" + actual + "\"");
+    }
+
+    static void assertOneEquals(final String message, final long expected, final long actual) {
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertOneEquals(final long expected, final long actual) {
+        assertOneEquals("OneLong mismatch: ", expected, actual);
+    }
+
+    private static void assertNullableEquals(final String message, final Long expected, final Long actual) {
+        if (expected == actual) return;
+        if (expected == null) Assert.fail(message + "expected was <null>, but actual was \"" + actual + "\"");
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertNullableEquals(final Long expected, final Long actual) {
+        assertNullableEquals("NullableLong mismatch: ", expected, actual);
+    }
+
+    private static void assertArrayOfOneEquals(final String message, final long[] expecteds, final long[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfOneEquals(final String message, final long[] expecteds, final long[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfOneEquals(final long[] expecteds, final long[] actuals) {
+        assertOneArrayOfOneEquals("OneArrayOfOneLong mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfOneEquals(final String message, final long[] expecteds, final long[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfOneEquals(final long[] expecteds, final long[] actuals) {
+        assertNullableArrayOfOneEquals("NullableArrayOfOneLong mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertArrayOfNullableEquals(final String message, final Long[] expecteds, final Long[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfNullableEquals(final String message, final Long[] expecteds, final Long[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfNullableEquals(final Long[] expecteds, final Long[] actuals) {
+        assertOneArrayOfNullableEquals("OneArrayOfNullableLong mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfNullableEquals(final String message, final Long[] expecteds, final Long[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfNullableEquals(final Long[] expecteds, final Long[] actuals) {
+        assertNullableArrayOfNullableEquals("NullableArrayOfNullableLong mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfOneEquals(final String message, final java.util.List<Long> expecteds, final java.util.List<Long> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<Long> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<Long> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final Long expected = expectedsIterator.next();
+            final Long actual = actualsIterator.next();
+            if (actual == null) {
+                Assert.fail(message + "element mismatch occurred at index " + i + ": expected was \"" + expected + "\", but actual was <null>");
+            }
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expected.longValue(), actual.longValue());
+        }
+    }
+
+    private static void assertOneListOfOneEquals(final String message, final java.util.List<Long> expecteds, final java.util.List<Long> actuals) {
+        int i = 0;
+        for (final Long expected : expecteds) {
+            if (expected == null) {
+                Assert.fail(message + "element mismatch occurred at index " + i + ": expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+            }
+            i++;
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfOneEquals(final java.util.List<Long> expecteds, final java.util.List<Long> actuals) {
+        assertOneListOfOneEquals("OneListOfOneLong mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfOneEquals(final String message, final java.util.List<Long> expecteds, final java.util.List<Long> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfOneEquals(final java.util.List<Long> expecteds, final java.util.List<Long> actuals) {
+        assertNullableListOfOneEquals("NullableListOfOneLong mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfNullableEquals(final String message, final java.util.List<Long> expecteds, final java.util.List<Long> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<Long> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<Long> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final Long expected = expectedsIterator.next();
+            final Long actual = actualsIterator.next();
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfNullableEquals(final String message, final java.util.List<Long> expecteds, final java.util.List<Long> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfNullableEquals(final java.util.List<Long> expecteds, final java.util.List<Long> actuals) {
+        assertOneListOfNullableEquals("OneListOfNullableLong mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfNullableEquals(final String message, final java.util.List<Long> expecteds, final java.util.List<Long> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfNullableEquals(final java.util.List<Long> expecteds, final java.util.List<Long> actuals) {
+        assertNullableListOfNullableEquals("NullableListOfNullableLong mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfOneEquals(final String message, final java.util.Set<Long> expecteds, final java.util.Set<Long> actuals) {
+        if (actuals.contains(null)) {
+            Assert.fail(message + "actuals contained a <null> element");
+        }
+
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        for (final Long expected : expecteds) {
+            if (!actuals.contains(expected)) {
+                Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+            }
+        }
+    }
+
+    private static void assertOneSetOfOneEquals(final String message, final java.util.Set<Long> expecteds, final java.util.Set<Long> actuals) {
+        if (expecteds.contains(null)) {
+            Assert.fail(message + "expecteds contained a <null> element - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfOneEquals(final java.util.Set<Long> expecteds, final java.util.Set<Long> actuals) {
+        assertOneSetOfOneEquals("OneSetOfOneLong mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfOneEquals(final String message, final java.util.Set<Long> expecteds, final java.util.Set<Long> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfOneEquals(final java.util.Set<Long> expecteds, final java.util.Set<Long> actuals) {
+        assertNullableSetOfOneEquals("NullableSetOfOneLong mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfNullableEquals(final String message, final java.util.Set<Long> expecteds, final java.util.Set<Long> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        for (final Long expected : expecteds) {
+            if (!actuals.contains(expected)) {
+                Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+            }
+        }
+    }
+
+    private static void assertOneSetOfNullableEquals(final String message, final java.util.Set<Long> expecteds, final java.util.Set<Long> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfNullableEquals(final java.util.Set<Long> expecteds, final java.util.Set<Long> actuals) {
+        assertOneSetOfNullableEquals("OneSetOfNullableLong mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfNullableEquals(final String message, final java.util.Set<Long> expecteds, final java.util.Set<Long> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfNullableEquals(final java.util.Set<Long> expecteds, final java.util.Set<Long> actuals) {
+        assertNullableSetOfNullableEquals("NullableSetOfNullableLong mismatch: ", expecteds, actuals);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/MapAsserts.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/MapAsserts.java
@@ -1,0 +1,269 @@
+package com.dslplatform.ocd.javaasserts;
+
+import org.junit.Assert;
+
+public class MapAsserts {
+    static void assertSingleEquals(final String message, final java.util.Map<String, String> expected, final java.util.Map<String, String> actual) {
+        if (expected.containsKey(null)) {
+            Assert.fail(message + "expected contained a <null> key - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        }
+
+        if (actual.containsKey(null)) {
+            Assert.fail(message + "actual contained a <null> key");
+        }
+
+        if (expected.equals(actual)) return;
+        Assert.fail(message + "expected was \"" + expected + "\", but actual was \"" + actual + "\"");
+    }
+
+    static void assertOneEquals(final String message, final java.util.Map<String, String> expected, final java.util.Map<String, String> actual) {
+        if (expected == null) Assert.fail(message + "expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        if (expected == actual) return;
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertOneEquals(final java.util.Map<String, String> expected, final java.util.Map<String, String> actual) {
+        assertOneEquals("OneMap mismatch: ", expected, actual);
+    }
+
+    private static void assertNullableEquals(final String message, final java.util.Map<String, String> expected, final java.util.Map<String, String> actual) {
+        if (expected == actual) return;
+        if (expected == null) Assert.fail(message + "expected was <null>, but actual was \"" + actual + "\"");
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertNullableEquals(final java.util.Map<String, String> expected, final java.util.Map<String, String> actual) {
+        assertNullableEquals("NullableMap mismatch: ", expected, actual);
+    }
+
+    private static void assertArrayOfOneEquals(final String message, final java.util.Map<String, String>[] expecteds, final java.util.Map<String, String>[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfOneEquals(final String message, final java.util.Map<String, String>[] expecteds, final java.util.Map<String, String>[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        for (int i = 0; i < expecteds.length; i ++) {
+            if (expecteds[i] == null) {
+                Assert.fail(message + "expecteds contained a <null> element at index " + i + " - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+            }
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfOneEquals(final java.util.Map<String, String>[] expecteds, final java.util.Map<String, String>[] actuals) {
+        assertOneArrayOfOneEquals("OneArrayOfOneMap mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfOneEquals(final String message, final java.util.Map<String, String>[] expecteds, final java.util.Map<String, String>[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfOneEquals(final java.util.Map<String, String>[] expecteds, final java.util.Map<String, String>[] actuals) {
+        assertNullableArrayOfOneEquals("NullableArrayOfOneMap mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertArrayOfNullableEquals(final String message, final java.util.Map<String, String>[] expecteds, final java.util.Map<String, String>[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfNullableEquals(final String message, final java.util.Map<String, String>[] expecteds, final java.util.Map<String, String>[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfNullableEquals(final java.util.Map<String, String>[] expecteds, final java.util.Map<String, String>[] actuals) {
+        assertOneArrayOfNullableEquals("OneArrayOfNullableMap mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfNullableEquals(final String message, final java.util.Map<String, String>[] expecteds, final java.util.Map<String, String>[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfNullableEquals(final java.util.Map<String, String>[] expecteds, final java.util.Map<String, String>[] actuals) {
+        assertNullableArrayOfNullableEquals("NullableArrayOfNullableMap mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfOneEquals(final String message, final java.util.List<java.util.Map<String, String>> expecteds, final java.util.List<java.util.Map<String, String>> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<java.util.Map<String, String>> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<java.util.Map<String, String>> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final java.util.Map<String, String> expected = expectedsIterator.next();
+            final java.util.Map<String, String> actual = actualsIterator.next();
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfOneEquals(final String message, final java.util.List<java.util.Map<String, String>> expecteds, final java.util.List<java.util.Map<String, String>> actuals) {
+        int i = 0;
+        for (final java.util.Map<String, String> expected : expecteds) {
+            if (expected == null) {
+                Assert.fail(message + "element mismatch occurred at index " + i + ": expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+            }
+            i++;
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfOneEquals(final java.util.List<java.util.Map<String, String>> expecteds, final java.util.List<java.util.Map<String, String>> actuals) {
+        assertOneListOfOneEquals("OneListOfOneMap mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfOneEquals(final String message, final java.util.List<java.util.Map<String, String>> expecteds, final java.util.List<java.util.Map<String, String>> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfOneEquals(final java.util.List<java.util.Map<String, String>> expecteds, final java.util.List<java.util.Map<String, String>> actuals) {
+        assertNullableListOfOneEquals("NullableListOfOneMap mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfNullableEquals(final String message, final java.util.List<java.util.Map<String, String>> expecteds, final java.util.List<java.util.Map<String, String>> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<java.util.Map<String, String>> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<java.util.Map<String, String>> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final java.util.Map<String, String> expected = expectedsIterator.next();
+            final java.util.Map<String, String> actual = actualsIterator.next();
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfNullableEquals(final String message, final java.util.List<java.util.Map<String, String>> expecteds, final java.util.List<java.util.Map<String, String>> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfNullableEquals(final java.util.List<java.util.Map<String, String>> expecteds, final java.util.List<java.util.Map<String, String>> actuals) {
+        assertOneListOfNullableEquals("OneListOfNullableMap mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfNullableEquals(final String message, final java.util.List<java.util.Map<String, String>> expecteds, final java.util.List<java.util.Map<String, String>> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfNullableEquals(final java.util.List<java.util.Map<String, String>> expecteds, final java.util.List<java.util.Map<String, String>> actuals) {
+        assertNullableListOfNullableEquals("NullableListOfNullableMap mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfOneEquals(final String message, final java.util.Set<java.util.Map<String, String>> expecteds, final java.util.Set<java.util.Map<String, String>> actuals) {
+        if (actuals.contains(null)) {
+            Assert.fail(message + "actuals contained a <null> element");
+        }
+
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        for (final java.util.Map<String, String> expected : expecteds) {
+            if (!actuals.contains(expected)) {
+                Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+            }
+        }
+    }
+
+    private static void assertOneSetOfOneEquals(final String message, final java.util.Set<java.util.Map<String, String>> expecteds, final java.util.Set<java.util.Map<String, String>> actuals) {
+        if (expecteds.contains(null)) {
+            Assert.fail(message + "expecteds contained a <null> element - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfOneEquals(final java.util.Set<java.util.Map<String, String>> expecteds, final java.util.Set<java.util.Map<String, String>> actuals) {
+        assertOneSetOfOneEquals("OneSetOfOneMap mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfOneEquals(final String message, final java.util.Set<java.util.Map<String, String>> expecteds, final java.util.Set<java.util.Map<String, String>> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfOneEquals(final java.util.Set<java.util.Map<String, String>> expecteds, final java.util.Set<java.util.Map<String, String>> actuals) {
+        assertNullableSetOfOneEquals("NullableSetOfOneMap mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfNullableEquals(final String message, final java.util.Set<java.util.Map<String, String>> expecteds, final java.util.Set<java.util.Map<String, String>> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        for (final java.util.Map<String, String> expected : expecteds) {
+            if (!actuals.contains(expected)) {
+                Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+            }
+        }
+    }
+
+    private static void assertOneSetOfNullableEquals(final String message, final java.util.Set<java.util.Map<String, String>> expecteds, final java.util.Set<java.util.Map<String, String>> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfNullableEquals(final java.util.Set<java.util.Map<String, String>> expecteds, final java.util.Set<java.util.Map<String, String>> actuals) {
+        assertOneSetOfNullableEquals("OneSetOfNullableMap mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfNullableEquals(final String message, final java.util.Set<java.util.Map<String, String>> expecteds, final java.util.Set<java.util.Map<String, String>> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfNullableEquals(final java.util.Set<java.util.Map<String, String>> expecteds, final java.util.Set<java.util.Map<String, String>> actuals) {
+        assertNullableSetOfNullableEquals("NullableSetOfNullableMap mismatch: ", expecteds, actuals);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/MoneyAsserts.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/MoneyAsserts.java
@@ -1,0 +1,287 @@
+package com.dslplatform.ocd.javaasserts;
+
+import org.junit.Assert;
+
+public class MoneyAsserts {
+    static void assertSingleEquals(final String message, final java.math.BigDecimal expected, final java.math.BigDecimal actual) {
+        try {
+            expected.setScale(2);
+        }
+        catch (final ArithmeticException e) {
+            Assert.fail(message + "expected was a DecimalWithScaleOf9, but its scale was " + expected.scale() + " - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        }
+
+        try {
+            expected.setScale(2);
+        }
+        catch (final ArithmeticException e) {
+            Assert.fail(message + "actual was a DecimalWithScaleOf9, but its scale was " + actual.scale());
+        }
+
+        if (expected == actual || expected.compareTo(actual) == 0) return;
+        Assert.fail(message + "expected was \"" + expected + "\", but actual was \"" + actual + "\"");
+    }
+
+    static void assertOneEquals(final String message, final java.math.BigDecimal expected, final java.math.BigDecimal actual) {
+        if (expected == null) Assert.fail(message + "expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        if (expected == actual) return;
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertOneEquals(final java.math.BigDecimal expected, final java.math.BigDecimal actual) {
+        assertOneEquals("OneMoney mismatch: ", expected, actual);
+    }
+
+    private static void assertNullableEquals(final String message, final java.math.BigDecimal expected, final java.math.BigDecimal actual) {
+        if (expected == actual) return;
+        if (expected == null) Assert.fail(message + "expected was <null>, but actual was \"" + actual + "\"");
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertNullableEquals(final java.math.BigDecimal expected, final java.math.BigDecimal actual) {
+        assertNullableEquals("NullableMoney mismatch: ", expected, actual);
+    }
+
+    private static void assertArrayOfOneEquals(final String message, final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfOneEquals(final String message, final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        for (int i = 0; i < expecteds.length; i ++) {
+            if (expecteds[i] == null) {
+                Assert.fail(message + "expecteds contained a <null> element at index " + i + " - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+            }
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfOneEquals(final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        assertOneArrayOfOneEquals("OneArrayOfOneMoney mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfOneEquals(final String message, final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfOneEquals(final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        assertNullableArrayOfOneEquals("NullableArrayOfOneMoney mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertArrayOfNullableEquals(final String message, final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfNullableEquals(final String message, final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfNullableEquals(final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        assertOneArrayOfNullableEquals("OneArrayOfNullableMoney mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfNullableEquals(final String message, final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfNullableEquals(final java.math.BigDecimal[] expecteds, final java.math.BigDecimal[] actuals) {
+        assertNullableArrayOfNullableEquals("NullableArrayOfNullableMoney mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfOneEquals(final String message, final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<java.math.BigDecimal> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<java.math.BigDecimal> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final java.math.BigDecimal expected = expectedsIterator.next();
+            final java.math.BigDecimal actual = actualsIterator.next();
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfOneEquals(final String message, final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        int i = 0;
+        for (final java.math.BigDecimal expected : expecteds) {
+            if (expected == null) {
+                Assert.fail(message + "element mismatch occurred at index " + i + ": expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+            }
+            i++;
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfOneEquals(final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        assertOneListOfOneEquals("OneListOfOneMoney mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfOneEquals(final String message, final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfOneEquals(final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        assertNullableListOfOneEquals("NullableListOfOneMoney mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfNullableEquals(final String message, final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<java.math.BigDecimal> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<java.math.BigDecimal> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final java.math.BigDecimal expected = expectedsIterator.next();
+            final java.math.BigDecimal actual = actualsIterator.next();
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfNullableEquals(final String message, final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfNullableEquals(final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        assertOneListOfNullableEquals("OneListOfNullableMoney mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfNullableEquals(final String message, final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfNullableEquals(final java.util.List<java.math.BigDecimal> expecteds, final java.util.List<java.math.BigDecimal> actuals) {
+        assertNullableListOfNullableEquals("NullableListOfNullableMoney mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfOneEquals(final String message, final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        if (actuals.contains(null)) {
+            Assert.fail(message + "actuals contained a <null> element");
+        }
+
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        expectedsLoop: for (final java.math.BigDecimal expected : expecteds) {
+            if (actuals.contains(expected)) continue;
+            for (final java.math.BigDecimal actual : actuals) {
+                try {
+                    assertOneEquals(expected, actual);
+                    continue expectedsLoop;
+                }
+                catch (final AssertionError e) {}
+            }
+            Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+        }
+    }
+
+    private static void assertOneSetOfOneEquals(final String message, final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        if (expecteds.contains(null)) {
+            Assert.fail(message + "expecteds contained a <null> element - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfOneEquals(final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        assertOneSetOfOneEquals("OneSetOfOneMoney mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfOneEquals(final String message, final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfOneEquals(final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        assertNullableSetOfOneEquals("NullableSetOfOneMoney mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfNullableEquals(final String message, final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        expectedsLoop: for (final java.math.BigDecimal expected : expecteds) {
+            if (actuals.contains(expected)) continue;
+            for (final java.math.BigDecimal actual : actuals) {
+                try {
+                    assertNullableEquals(expected, actual);
+                    continue expectedsLoop;
+                }
+                catch (final AssertionError e) {}
+            }
+            Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+        }
+    }
+
+    private static void assertOneSetOfNullableEquals(final String message, final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfNullableEquals(final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        assertOneSetOfNullableEquals("OneSetOfNullableMoney mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfNullableEquals(final String message, final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfNullableEquals(final java.util.Set<java.math.BigDecimal> expecteds, final java.util.Set<java.math.BigDecimal> actuals) {
+        assertNullableSetOfNullableEquals("NullableSetOfNullableMoney mismatch: ", expecteds, actuals);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/PointAsserts.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/PointAsserts.java
@@ -1,0 +1,261 @@
+package com.dslplatform.ocd.javaasserts;
+
+import org.junit.Assert;
+
+public class PointAsserts {
+    static void assertSingleEquals(final String message, final java.awt.Point expected, final java.awt.Point actual) {
+        if (expected.equals(actual)) return;
+        Assert.fail(message + "expected was \"" + expected + "\", but actual was \"" + actual + "\"");
+    }
+
+    static void assertOneEquals(final String message, final java.awt.Point expected, final java.awt.Point actual) {
+        if (expected == null) Assert.fail(message + "expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        if (expected == actual) return;
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertOneEquals(final java.awt.Point expected, final java.awt.Point actual) {
+        assertOneEquals("OnePoint mismatch: ", expected, actual);
+    }
+
+    private static void assertNullableEquals(final String message, final java.awt.Point expected, final java.awt.Point actual) {
+        if (expected == actual) return;
+        if (expected == null) Assert.fail(message + "expected was <null>, but actual was \"" + actual + "\"");
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertNullableEquals(final java.awt.Point expected, final java.awt.Point actual) {
+        assertNullableEquals("NullablePoint mismatch: ", expected, actual);
+    }
+
+    private static void assertArrayOfOneEquals(final String message, final java.awt.Point[] expecteds, final java.awt.Point[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfOneEquals(final String message, final java.awt.Point[] expecteds, final java.awt.Point[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        for (int i = 0; i < expecteds.length; i ++) {
+            if (expecteds[i] == null) {
+                Assert.fail(message + "expecteds contained a <null> element at index " + i + " - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+            }
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfOneEquals(final java.awt.Point[] expecteds, final java.awt.Point[] actuals) {
+        assertOneArrayOfOneEquals("OneArrayOfOnePoint mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfOneEquals(final String message, final java.awt.Point[] expecteds, final java.awt.Point[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfOneEquals(final java.awt.Point[] expecteds, final java.awt.Point[] actuals) {
+        assertNullableArrayOfOneEquals("NullableArrayOfOnePoint mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertArrayOfNullableEquals(final String message, final java.awt.Point[] expecteds, final java.awt.Point[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfNullableEquals(final String message, final java.awt.Point[] expecteds, final java.awt.Point[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfNullableEquals(final java.awt.Point[] expecteds, final java.awt.Point[] actuals) {
+        assertOneArrayOfNullableEquals("OneArrayOfNullablePoint mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfNullableEquals(final String message, final java.awt.Point[] expecteds, final java.awt.Point[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfNullableEquals(final java.awt.Point[] expecteds, final java.awt.Point[] actuals) {
+        assertNullableArrayOfNullableEquals("NullableArrayOfNullablePoint mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfOneEquals(final String message, final java.util.List<java.awt.Point> expecteds, final java.util.List<java.awt.Point> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<java.awt.Point> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<java.awt.Point> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final java.awt.Point expected = expectedsIterator.next();
+            final java.awt.Point actual = actualsIterator.next();
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfOneEquals(final String message, final java.util.List<java.awt.Point> expecteds, final java.util.List<java.awt.Point> actuals) {
+        int i = 0;
+        for (final java.awt.Point expected : expecteds) {
+            if (expected == null) {
+                Assert.fail(message + "element mismatch occurred at index " + i + ": expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+            }
+            i++;
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfOneEquals(final java.util.List<java.awt.Point> expecteds, final java.util.List<java.awt.Point> actuals) {
+        assertOneListOfOneEquals("OneListOfOnePoint mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfOneEquals(final String message, final java.util.List<java.awt.Point> expecteds, final java.util.List<java.awt.Point> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfOneEquals(final java.util.List<java.awt.Point> expecteds, final java.util.List<java.awt.Point> actuals) {
+        assertNullableListOfOneEquals("NullableListOfOnePoint mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfNullableEquals(final String message, final java.util.List<java.awt.Point> expecteds, final java.util.List<java.awt.Point> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<java.awt.Point> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<java.awt.Point> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final java.awt.Point expected = expectedsIterator.next();
+            final java.awt.Point actual = actualsIterator.next();
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfNullableEquals(final String message, final java.util.List<java.awt.Point> expecteds, final java.util.List<java.awt.Point> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfNullableEquals(final java.util.List<java.awt.Point> expecteds, final java.util.List<java.awt.Point> actuals) {
+        assertOneListOfNullableEquals("OneListOfNullablePoint mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfNullableEquals(final String message, final java.util.List<java.awt.Point> expecteds, final java.util.List<java.awt.Point> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfNullableEquals(final java.util.List<java.awt.Point> expecteds, final java.util.List<java.awt.Point> actuals) {
+        assertNullableListOfNullableEquals("NullableListOfNullablePoint mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfOneEquals(final String message, final java.util.Set<java.awt.Point> expecteds, final java.util.Set<java.awt.Point> actuals) {
+        if (actuals.contains(null)) {
+            Assert.fail(message + "actuals contained a <null> element");
+        }
+
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        for (final java.awt.Point expected : expecteds) {
+            if (!actuals.contains(expected)) {
+                Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+            }
+        }
+    }
+
+    private static void assertOneSetOfOneEquals(final String message, final java.util.Set<java.awt.Point> expecteds, final java.util.Set<java.awt.Point> actuals) {
+        if (expecteds.contains(null)) {
+            Assert.fail(message + "expecteds contained a <null> element - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfOneEquals(final java.util.Set<java.awt.Point> expecteds, final java.util.Set<java.awt.Point> actuals) {
+        assertOneSetOfOneEquals("OneSetOfOnePoint mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfOneEquals(final String message, final java.util.Set<java.awt.Point> expecteds, final java.util.Set<java.awt.Point> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfOneEquals(final java.util.Set<java.awt.Point> expecteds, final java.util.Set<java.awt.Point> actuals) {
+        assertNullableSetOfOneEquals("NullableSetOfOnePoint mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfNullableEquals(final String message, final java.util.Set<java.awt.Point> expecteds, final java.util.Set<java.awt.Point> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        for (final java.awt.Point expected : expecteds) {
+            if (!actuals.contains(expected)) {
+                Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+            }
+        }
+    }
+
+    private static void assertOneSetOfNullableEquals(final String message, final java.util.Set<java.awt.Point> expecteds, final java.util.Set<java.awt.Point> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfNullableEquals(final java.util.Set<java.awt.Point> expecteds, final java.util.Set<java.awt.Point> actuals) {
+        assertOneSetOfNullableEquals("OneSetOfNullablePoint mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfNullableEquals(final String message, final java.util.Set<java.awt.Point> expecteds, final java.util.Set<java.awt.Point> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfNullableEquals(final java.util.Set<java.awt.Point> expecteds, final java.util.Set<java.awt.Point> actuals) {
+        assertNullableSetOfNullableEquals("NullableSetOfNullablePoint mismatch: ", expecteds, actuals);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/RectangleAsserts.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/RectangleAsserts.java
@@ -1,0 +1,331 @@
+package com.dslplatform.ocd.javaasserts;
+
+import org.junit.Assert;
+
+public class RectangleAsserts {
+    static void assertSingleEquals(final String message, final java.awt.geom.Rectangle2D expected, final java.awt.geom.Rectangle2D actual, final int ulps) {
+        FloatAsserts.assertOneEquals(message + ": comparing X coordinate: ", (float) expected.getX(), (float) actual.getX(), ulps);
+        FloatAsserts.assertOneEquals(message + ": comparing Y coordinate: ", (float) expected.getY(), (float) actual.getY(), ulps);
+        FloatAsserts.assertOneEquals(message + ": comparing width: ", (float) expected.getWidth(), (float) actual.getWidth(), ulps);
+        FloatAsserts.assertOneEquals(message + ": comparing height: ", (float) expected.getHeight(), (float) actual.getHeight(), ulps);
+    }
+
+    static void assertOneEquals(final String message, final java.awt.geom.Rectangle2D expected, final java.awt.geom.Rectangle2D actual, final int ulps) {
+        if (expected == null) Assert.fail(message + "expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        if (expected == actual) return;
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual, ulps);
+    }
+
+    public static void assertOneEquals(final java.awt.geom.Rectangle2D expected, final java.awt.geom.Rectangle2D actual, final int ulps) {
+        assertOneEquals("OneRectangle mismatch: ", expected, actual, ulps);
+    }
+
+    public static void assertOneEquals(final java.awt.geom.Rectangle2D expected, final java.awt.geom.Rectangle2D actual) {
+        assertOneEquals(expected, actual, 0);
+    }
+
+    private static void assertNullableEquals(final String message, final java.awt.geom.Rectangle2D expected, final java.awt.geom.Rectangle2D actual, final int ulps) {
+        if (expected == actual) return;
+        if (expected == null) Assert.fail(message + "expected was <null>, but actual was \"" + actual + "\"");
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual, ulps);
+    }
+
+    public static void assertNullableEquals(final java.awt.geom.Rectangle2D expected, final java.awt.geom.Rectangle2D actual, final int ulps) {
+        assertNullableEquals("NullableRectangle mismatch: ", expected, actual, ulps);
+    }
+
+    public static void assertNullableEquals(final java.awt.geom.Rectangle2D expected, final java.awt.geom.Rectangle2D actual) {
+        assertNullableEquals(expected, actual, 0);
+    }
+
+    private static void assertArrayOfOneEquals(final String message, final java.awt.geom.Rectangle2D[] expecteds, final java.awt.geom.Rectangle2D[] actuals, final int ulps) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i], ulps);
+        }
+    }
+
+    private static void assertOneArrayOfOneEquals(final String message, final java.awt.geom.Rectangle2D[] expecteds, final java.awt.geom.Rectangle2D[] actuals, final int ulps) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        for (int i = 0; i < expecteds.length; i ++) {
+            if (expecteds[i] == null) {
+                Assert.fail(message + "expecteds contained a <null> element at index " + i + " - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+            }
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertOneArrayOfOneEquals(final java.awt.geom.Rectangle2D[] expecteds, final java.awt.geom.Rectangle2D[] actuals, final int ulps) {
+        assertOneArrayOfOneEquals("OneArrayOfOneRectangle mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertOneArrayOfOneEquals(final java.awt.geom.Rectangle2D[] expecteds, final java.awt.geom.Rectangle2D[] actuals) {
+        assertOneArrayOfOneEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertNullableArrayOfOneEquals(final String message, final java.awt.geom.Rectangle2D[] expecteds, final java.awt.geom.Rectangle2D[] actuals, final int ulps) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableArrayOfOneEquals(final java.awt.geom.Rectangle2D[] expecteds, final java.awt.geom.Rectangle2D[] actuals, final int ulps) {
+        assertNullableArrayOfOneEquals("NullableArrayOfOneRectangle mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableArrayOfOneEquals(final java.awt.geom.Rectangle2D[] expecteds, final java.awt.geom.Rectangle2D[] actuals) {
+        assertNullableArrayOfOneEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertArrayOfNullableEquals(final String message, final java.awt.geom.Rectangle2D[] expecteds, final java.awt.geom.Rectangle2D[] actuals, final int ulps) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i], ulps);
+        }
+    }
+
+    private static void assertOneArrayOfNullableEquals(final String message, final java.awt.geom.Rectangle2D[] expecteds, final java.awt.geom.Rectangle2D[] actuals, final int ulps) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertOneArrayOfNullableEquals(final java.awt.geom.Rectangle2D[] expecteds, final java.awt.geom.Rectangle2D[] actuals, final int ulps) {
+        assertOneArrayOfNullableEquals("OneArrayOfNullableRectangle mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertOneArrayOfNullableEquals(final java.awt.geom.Rectangle2D[] expecteds, final java.awt.geom.Rectangle2D[] actuals) {
+        assertOneArrayOfNullableEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertNullableArrayOfNullableEquals(final String message, final java.awt.geom.Rectangle2D[] expecteds, final java.awt.geom.Rectangle2D[] actuals, final int ulps) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableArrayOfNullableEquals(final java.awt.geom.Rectangle2D[] expecteds, final java.awt.geom.Rectangle2D[] actuals, final int ulps) {
+        assertNullableArrayOfNullableEquals("NullableArrayOfNullableRectangle mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableArrayOfNullableEquals(final java.awt.geom.Rectangle2D[] expecteds, final java.awt.geom.Rectangle2D[] actuals) {
+        assertNullableArrayOfNullableEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertListOfOneEquals(final String message, final java.util.List<java.awt.geom.Rectangle2D> expecteds, final java.util.List<java.awt.geom.Rectangle2D> actuals, final int ulps) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<java.awt.geom.Rectangle2D> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<java.awt.geom.Rectangle2D> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final java.awt.geom.Rectangle2D expected = expectedsIterator.next();
+            final java.awt.geom.Rectangle2D actual = actualsIterator.next();
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual, ulps);
+        }
+    }
+
+    private static void assertOneListOfOneEquals(final String message, final java.util.List<java.awt.geom.Rectangle2D> expecteds, final java.util.List<java.awt.geom.Rectangle2D> actuals, final int ulps) {
+        int i = 0;
+        for (final java.awt.geom.Rectangle2D expected : expecteds) {
+            if (expected == null) {
+                Assert.fail(message + "element mismatch occurred at index " + i + ": expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+            }
+            i++;
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertOneListOfOneEquals(final java.util.List<java.awt.geom.Rectangle2D> expecteds, final java.util.List<java.awt.geom.Rectangle2D> actuals, final int ulps) {
+        assertOneListOfOneEquals("OneListOfOneRectangle mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertOneListOfOneEquals(final java.util.List<java.awt.geom.Rectangle2D> expecteds, final java.util.List<java.awt.geom.Rectangle2D> actuals) {
+        assertOneListOfOneEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertNullableListOfOneEquals(final String message, final java.util.List<java.awt.geom.Rectangle2D> expecteds, final java.util.List<java.awt.geom.Rectangle2D> actuals, final int ulps) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableListOfOneEquals(final java.util.List<java.awt.geom.Rectangle2D> expecteds, final java.util.List<java.awt.geom.Rectangle2D> actuals, final int ulps) {
+        assertNullableListOfOneEquals("NullableListOfOneRectangle mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableListOfOneEquals(final java.util.List<java.awt.geom.Rectangle2D> expecteds, final java.util.List<java.awt.geom.Rectangle2D> actuals) {
+        assertNullableListOfOneEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertListOfNullableEquals(final String message, final java.util.List<java.awt.geom.Rectangle2D> expecteds, final java.util.List<java.awt.geom.Rectangle2D> actuals, final int ulps) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<java.awt.geom.Rectangle2D> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<java.awt.geom.Rectangle2D> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final java.awt.geom.Rectangle2D expected = expectedsIterator.next();
+            final java.awt.geom.Rectangle2D actual = actualsIterator.next();
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual, ulps);
+        }
+    }
+
+    private static void assertOneListOfNullableEquals(final String message, final java.util.List<java.awt.geom.Rectangle2D> expecteds, final java.util.List<java.awt.geom.Rectangle2D> actuals, final int ulps) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertOneListOfNullableEquals(final java.util.List<java.awt.geom.Rectangle2D> expecteds, final java.util.List<java.awt.geom.Rectangle2D> actuals, final int ulps) {
+        assertOneListOfNullableEquals("OneListOfNullableRectangle mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertOneListOfNullableEquals(final java.util.List<java.awt.geom.Rectangle2D> expecteds, final java.util.List<java.awt.geom.Rectangle2D> actuals) {
+        assertOneListOfNullableEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertNullableListOfNullableEquals(final String message, final java.util.List<java.awt.geom.Rectangle2D> expecteds, final java.util.List<java.awt.geom.Rectangle2D> actuals, final int ulps) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableListOfNullableEquals(final java.util.List<java.awt.geom.Rectangle2D> expecteds, final java.util.List<java.awt.geom.Rectangle2D> actuals, final int ulps) {
+        assertNullableListOfNullableEquals("NullableListOfNullableRectangle mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableListOfNullableEquals(final java.util.List<java.awt.geom.Rectangle2D> expecteds, final java.util.List<java.awt.geom.Rectangle2D> actuals) {
+        assertNullableListOfNullableEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertSetOfOneEquals(final String message, final java.util.Set<java.awt.geom.Rectangle2D> expecteds, final java.util.Set<java.awt.geom.Rectangle2D> actuals, final int ulps) {
+        if (actuals.contains(null)) {
+            Assert.fail(message + "actuals contained a <null> element");
+        }
+
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        expectedsLoop: for (final java.awt.geom.Rectangle2D expected : expecteds) {
+            if (actuals.contains(expected)) continue;
+            for (final java.awt.geom.Rectangle2D actual : actuals) {
+                try {
+                    assertOneEquals(expected, actual, ulps);
+                    continue expectedsLoop;
+                }
+                catch (final AssertionError e) {}
+            }
+            Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+        }
+    }
+
+    private static void assertOneSetOfOneEquals(final String message, final java.util.Set<java.awt.geom.Rectangle2D> expecteds, final java.util.Set<java.awt.geom.Rectangle2D> actuals, final int ulps) {
+        if (expecteds.contains(null)) {
+            Assert.fail(message + "expecteds contained a <null> element - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertOneSetOfOneEquals(final java.util.Set<java.awt.geom.Rectangle2D> expecteds, final java.util.Set<java.awt.geom.Rectangle2D> actuals, final int ulps) {
+        assertOneSetOfOneEquals("OneSetOfOneRectangle mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertOneSetOfOneEquals(final java.util.Set<java.awt.geom.Rectangle2D> expecteds, final java.util.Set<java.awt.geom.Rectangle2D> actuals) {
+        assertOneSetOfOneEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertNullableSetOfOneEquals(final String message, final java.util.Set<java.awt.geom.Rectangle2D> expecteds, final java.util.Set<java.awt.geom.Rectangle2D> actuals, final int ulps) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableSetOfOneEquals(final java.util.Set<java.awt.geom.Rectangle2D> expecteds, final java.util.Set<java.awt.geom.Rectangle2D> actuals, final int ulps) {
+        assertNullableSetOfOneEquals("NullableSetOfOneRectangle mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableSetOfOneEquals(final java.util.Set<java.awt.geom.Rectangle2D> expecteds, final java.util.Set<java.awt.geom.Rectangle2D> actuals) {
+        assertNullableSetOfOneEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertSetOfNullableEquals(final String message, final java.util.Set<java.awt.geom.Rectangle2D> expecteds, final java.util.Set<java.awt.geom.Rectangle2D> actuals, final int ulps) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        expectedsLoop: for (final java.awt.geom.Rectangle2D expected : expecteds) {
+            if (actuals.contains(expected)) continue;
+            for (final java.awt.geom.Rectangle2D actual : actuals) {
+                try {
+                    assertNullableEquals(expected, actual, ulps);
+                    continue expectedsLoop;
+                }
+                catch (final AssertionError e) {}
+            }
+            Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+        }
+    }
+
+    private static void assertOneSetOfNullableEquals(final String message, final java.util.Set<java.awt.geom.Rectangle2D> expecteds, final java.util.Set<java.awt.geom.Rectangle2D> actuals, final int ulps) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertOneSetOfNullableEquals(final java.util.Set<java.awt.geom.Rectangle2D> expecteds, final java.util.Set<java.awt.geom.Rectangle2D> actuals, final int ulps) {
+        assertOneSetOfNullableEquals("OneSetOfNullableRectangle mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertOneSetOfNullableEquals(final java.util.Set<java.awt.geom.Rectangle2D> expecteds, final java.util.Set<java.awt.geom.Rectangle2D> actuals) {
+        assertOneSetOfNullableEquals(expecteds, actuals, 0);
+    }
+
+    private static void assertNullableSetOfNullableEquals(final String message, final java.util.Set<java.awt.geom.Rectangle2D> expecteds, final java.util.Set<java.awt.geom.Rectangle2D> actuals, final int ulps) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableSetOfNullableEquals(final java.util.Set<java.awt.geom.Rectangle2D> expecteds, final java.util.Set<java.awt.geom.Rectangle2D> actuals, final int ulps) {
+        assertNullableSetOfNullableEquals("NullableSetOfNullableRectangle mismatch: ", expecteds, actuals, ulps);
+    }
+
+    public static void assertNullableSetOfNullableEquals(final java.util.Set<java.awt.geom.Rectangle2D> expecteds, final java.util.Set<java.awt.geom.Rectangle2D> actuals) {
+        assertNullableSetOfNullableEquals(expecteds, actuals, 0);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/StringAsserts.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/StringAsserts.java
@@ -1,0 +1,261 @@
+package com.dslplatform.ocd.javaasserts;
+
+import org.junit.Assert;
+
+public class StringAsserts {
+    static void assertSingleEquals(final String message, final String expected, final String actual) {
+        if (expected.equals(actual)) return;
+        Assert.fail(message + "expected was \"" + expected + "\", but actual was \"" + actual + "\"");
+    }
+
+    static void assertOneEquals(final String message, final String expected, final String actual) {
+        if (expected == null) Assert.fail(message + "expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        if (expected == actual) return;
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertOneEquals(final String expected, final String actual) {
+        assertOneEquals("OneString mismatch: ", expected, actual);
+    }
+
+    private static void assertNullableEquals(final String message, final String expected, final String actual) {
+        if (expected == actual) return;
+        if (expected == null) Assert.fail(message + "expected was <null>, but actual was \"" + actual + "\"");
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertNullableEquals(final String expected, final String actual) {
+        assertNullableEquals("NullableString mismatch: ", expected, actual);
+    }
+
+    private static void assertArrayOfOneEquals(final String message, final String[] expecteds, final String[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfOneEquals(final String message, final String[] expecteds, final String[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        for (int i = 0; i < expecteds.length; i ++) {
+            if (expecteds[i] == null) {
+                Assert.fail(message + "expecteds contained a <null> element at index " + i + " - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+            }
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfOneEquals(final String[] expecteds, final String[] actuals) {
+        assertOneArrayOfOneEquals("OneArrayOfOneString mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfOneEquals(final String message, final String[] expecteds, final String[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfOneEquals(final String[] expecteds, final String[] actuals) {
+        assertNullableArrayOfOneEquals("NullableArrayOfOneString mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertArrayOfNullableEquals(final String message, final String[] expecteds, final String[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfNullableEquals(final String message, final String[] expecteds, final String[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfNullableEquals(final String[] expecteds, final String[] actuals) {
+        assertOneArrayOfNullableEquals("OneArrayOfNullableString mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfNullableEquals(final String message, final String[] expecteds, final String[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfNullableEquals(final String[] expecteds, final String[] actuals) {
+        assertNullableArrayOfNullableEquals("NullableArrayOfNullableString mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfOneEquals(final String message, final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<String> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<String> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final String expected = expectedsIterator.next();
+            final String actual = actualsIterator.next();
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfOneEquals(final String message, final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        int i = 0;
+        for (final String expected : expecteds) {
+            if (expected == null) {
+                Assert.fail(message + "element mismatch occurred at index " + i + ": expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+            }
+            i++;
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfOneEquals(final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        assertOneListOfOneEquals("OneListOfOneString mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfOneEquals(final String message, final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfOneEquals(final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        assertNullableListOfOneEquals("NullableListOfOneString mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfNullableEquals(final String message, final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<String> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<String> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final String expected = expectedsIterator.next();
+            final String actual = actualsIterator.next();
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfNullableEquals(final String message, final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfNullableEquals(final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        assertOneListOfNullableEquals("OneListOfNullableString mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfNullableEquals(final String message, final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfNullableEquals(final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        assertNullableListOfNullableEquals("NullableListOfNullableString mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfOneEquals(final String message, final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        if (actuals.contains(null)) {
+            Assert.fail(message + "actuals contained a <null> element");
+        }
+
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        for (final String expected : expecteds) {
+            if (!actuals.contains(expected)) {
+                Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+            }
+        }
+    }
+
+    private static void assertOneSetOfOneEquals(final String message, final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        if (expecteds.contains(null)) {
+            Assert.fail(message + "expecteds contained a <null> element - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfOneEquals(final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        assertOneSetOfOneEquals("OneSetOfOneString mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfOneEquals(final String message, final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfOneEquals(final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        assertNullableSetOfOneEquals("NullableSetOfOneString mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfNullableEquals(final String message, final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        for (final String expected : expecteds) {
+            if (!actuals.contains(expected)) {
+                Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+            }
+        }
+    }
+
+    private static void assertOneSetOfNullableEquals(final String message, final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfNullableEquals(final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        assertOneSetOfNullableEquals("OneSetOfNullableString mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfNullableEquals(final String message, final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfNullableEquals(final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        assertNullableSetOfNullableEquals("NullableSetOfNullableString mismatch: ", expecteds, actuals);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/StringWithMaxLengthOf9Asserts.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/StringWithMaxLengthOf9Asserts.java
@@ -1,0 +1,269 @@
+package com.dslplatform.ocd.javaasserts;
+
+import org.junit.Assert;
+
+public class StringWithMaxLengthOf9Asserts {
+    static void assertSingleEquals(final String message, final String expected, final String actual) {
+        if (expected.length() > 9) {
+            Assert.fail(message + "expected was a StringWithMaxLengthOf9, but its length was " + expected.length() + " - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        }
+
+        if (actual.length() > 9) {
+            Assert.fail(message + "actual was a StringWithMaxLengthOf9, but its length was " + actual.length());
+        }
+
+        if (expected == actual || expected.equals(actual)) return;
+        Assert.fail(message + "expected was \"" + expected + "\", but actual was \"" + actual + "\"");
+    }
+
+    static void assertOneEquals(final String message, final String expected, final String actual) {
+        if (expected == null) Assert.fail(message + "expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        if (expected == actual) return;
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertOneEquals(final String expected, final String actual) {
+        assertOneEquals("OneStringWithMaxLengthOf9 mismatch: ", expected, actual);
+    }
+
+    private static void assertNullableEquals(final String message, final String expected, final String actual) {
+        if (expected == actual) return;
+        if (expected == null) Assert.fail(message + "expected was <null>, but actual was \"" + actual + "\"");
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertNullableEquals(final String expected, final String actual) {
+        assertNullableEquals("NullableStringWithMaxLengthOf9 mismatch: ", expected, actual);
+    }
+
+    private static void assertArrayOfOneEquals(final String message, final String[] expecteds, final String[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfOneEquals(final String message, final String[] expecteds, final String[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        for (int i = 0; i < expecteds.length; i ++) {
+            if (expecteds[i] == null) {
+                Assert.fail(message + "expecteds contained a <null> element at index " + i + " - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+            }
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfOneEquals(final String[] expecteds, final String[] actuals) {
+        assertOneArrayOfOneEquals("OneArrayOfOneStringWithMaxLengthOf9 mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfOneEquals(final String message, final String[] expecteds, final String[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfOneEquals(final String[] expecteds, final String[] actuals) {
+        assertNullableArrayOfOneEquals("NullableArrayOfOneStringWithMaxLengthOf9 mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertArrayOfNullableEquals(final String message, final String[] expecteds, final String[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfNullableEquals(final String message, final String[] expecteds, final String[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfNullableEquals(final String[] expecteds, final String[] actuals) {
+        assertOneArrayOfNullableEquals("OneArrayOfNullableStringWithMaxLengthOf9 mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfNullableEquals(final String message, final String[] expecteds, final String[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfNullableEquals(final String[] expecteds, final String[] actuals) {
+        assertNullableArrayOfNullableEquals("NullableArrayOfNullableStringWithMaxLengthOf9 mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfOneEquals(final String message, final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<String> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<String> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final String expected = expectedsIterator.next();
+            final String actual = actualsIterator.next();
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfOneEquals(final String message, final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        int i = 0;
+        for (final String expected : expecteds) {
+            if (expected == null) {
+                Assert.fail(message + "element mismatch occurred at index " + i + ": expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+            }
+            i++;
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfOneEquals(final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        assertOneListOfOneEquals("OneListOfOneStringWithMaxLengthOf9 mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfOneEquals(final String message, final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfOneEquals(final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        assertNullableListOfOneEquals("NullableListOfOneStringWithMaxLengthOf9 mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfNullableEquals(final String message, final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<String> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<String> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final String expected = expectedsIterator.next();
+            final String actual = actualsIterator.next();
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfNullableEquals(final String message, final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfNullableEquals(final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        assertOneListOfNullableEquals("OneListOfNullableStringWithMaxLengthOf9 mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfNullableEquals(final String message, final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfNullableEquals(final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        assertNullableListOfNullableEquals("NullableListOfNullableStringWithMaxLengthOf9 mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfOneEquals(final String message, final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        if (actuals.contains(null)) {
+            Assert.fail(message + "actuals contained a <null> element");
+        }
+
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        for (final String expected : expecteds) {
+            if (!actuals.contains(expected)) {
+                Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+            }
+        }
+    }
+
+    private static void assertOneSetOfOneEquals(final String message, final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        if (expecteds.contains(null)) {
+            Assert.fail(message + "expecteds contained a <null> element - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfOneEquals(final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        assertOneSetOfOneEquals("OneSetOfOneStringWithMaxLengthOf9 mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfOneEquals(final String message, final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfOneEquals(final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        assertNullableSetOfOneEquals("NullableSetOfOneStringWithMaxLengthOf9 mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfNullableEquals(final String message, final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        for (final String expected : expecteds) {
+            if (!actuals.contains(expected)) {
+                Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+            }
+        }
+    }
+
+    private static void assertOneSetOfNullableEquals(final String message, final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfNullableEquals(final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        assertOneSetOfNullableEquals("OneSetOfNullableStringWithMaxLengthOf9 mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfNullableEquals(final String message, final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfNullableEquals(final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        assertNullableSetOfNullableEquals("NullableSetOfNullableStringWithMaxLengthOf9 mismatch: ", expecteds, actuals);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/TextAsserts.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/TextAsserts.java
@@ -1,0 +1,261 @@
+package com.dslplatform.ocd.javaasserts;
+
+import org.junit.Assert;
+
+public class TextAsserts {
+    static void assertSingleEquals(final String message, final String expected, final String actual) {
+        if (expected.equals(actual)) return;
+        Assert.fail(message + "expected was \"" + expected + "\", but actual was \"" + actual + "\"");
+    }
+
+    static void assertOneEquals(final String message, final String expected, final String actual) {
+        if (expected == null) Assert.fail(message + "expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        if (expected == actual) return;
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertOneEquals(final String expected, final String actual) {
+        assertOneEquals("OneText mismatch: ", expected, actual);
+    }
+
+    private static void assertNullableEquals(final String message, final String expected, final String actual) {
+        if (expected == actual) return;
+        if (expected == null) Assert.fail(message + "expected was <null>, but actual was \"" + actual + "\"");
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertNullableEquals(final String expected, final String actual) {
+        assertNullableEquals("NullableText mismatch: ", expected, actual);
+    }
+
+    private static void assertArrayOfOneEquals(final String message, final String[] expecteds, final String[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfOneEquals(final String message, final String[] expecteds, final String[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        for (int i = 0; i < expecteds.length; i ++) {
+            if (expecteds[i] == null) {
+                Assert.fail(message + "expecteds contained a <null> element at index " + i + " - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+            }
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfOneEquals(final String[] expecteds, final String[] actuals) {
+        assertOneArrayOfOneEquals("OneArrayOfOneText mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfOneEquals(final String message, final String[] expecteds, final String[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfOneEquals(final String[] expecteds, final String[] actuals) {
+        assertNullableArrayOfOneEquals("NullableArrayOfOneText mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertArrayOfNullableEquals(final String message, final String[] expecteds, final String[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfNullableEquals(final String message, final String[] expecteds, final String[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfNullableEquals(final String[] expecteds, final String[] actuals) {
+        assertOneArrayOfNullableEquals("OneArrayOfNullableText mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfNullableEquals(final String message, final String[] expecteds, final String[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfNullableEquals(final String[] expecteds, final String[] actuals) {
+        assertNullableArrayOfNullableEquals("NullableArrayOfNullableText mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfOneEquals(final String message, final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<String> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<String> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final String expected = expectedsIterator.next();
+            final String actual = actualsIterator.next();
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfOneEquals(final String message, final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        int i = 0;
+        for (final String expected : expecteds) {
+            if (expected == null) {
+                Assert.fail(message + "element mismatch occurred at index " + i + ": expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+            }
+            i++;
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfOneEquals(final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        assertOneListOfOneEquals("OneListOfOneText mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfOneEquals(final String message, final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfOneEquals(final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        assertNullableListOfOneEquals("NullableListOfOneText mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfNullableEquals(final String message, final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<String> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<String> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final String expected = expectedsIterator.next();
+            final String actual = actualsIterator.next();
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfNullableEquals(final String message, final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfNullableEquals(final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        assertOneListOfNullableEquals("OneListOfNullableText mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfNullableEquals(final String message, final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfNullableEquals(final java.util.List<String> expecteds, final java.util.List<String> actuals) {
+        assertNullableListOfNullableEquals("NullableListOfNullableText mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfOneEquals(final String message, final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        if (actuals.contains(null)) {
+            Assert.fail(message + "actuals contained a <null> element");
+        }
+
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        for (final String expected : expecteds) {
+            if (!actuals.contains(expected)) {
+                Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+            }
+        }
+    }
+
+    private static void assertOneSetOfOneEquals(final String message, final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        if (expecteds.contains(null)) {
+            Assert.fail(message + "expecteds contained a <null> element - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfOneEquals(final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        assertOneSetOfOneEquals("OneSetOfOneText mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfOneEquals(final String message, final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfOneEquals(final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        assertNullableSetOfOneEquals("NullableSetOfOneText mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfNullableEquals(final String message, final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        for (final String expected : expecteds) {
+            if (!actuals.contains(expected)) {
+                Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+            }
+        }
+    }
+
+    private static void assertOneSetOfNullableEquals(final String message, final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfNullableEquals(final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        assertOneSetOfNullableEquals("OneSetOfNullableText mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfNullableEquals(final String message, final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfNullableEquals(final java.util.Set<String> expecteds, final java.util.Set<String> actuals) {
+        assertNullableSetOfNullableEquals("NullableSetOfNullableText mismatch: ", expecteds, actuals);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/TimestampAsserts.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/TimestampAsserts.java
@@ -1,0 +1,369 @@
+package com.dslplatform.ocd.javaasserts;
+
+import org.junit.Assert;
+
+public class TimestampAsserts {
+    static void assertSingleEquals(final String message, final org.joda.time.DateTime expected, final org.joda.time.DateTime actual, final org.joda.time.Duration delta) {
+        // TODO: Chronologies will not be compared if milliseconds were an exact match
+        final boolean EXACT_MILLIS_GOOD_ENOUGH = true;
+
+        if (delta == org.joda.time.Duration.ZERO) {
+            if (expected == actual || expected.equals(actual)) return;
+
+            final StringBuilder failMsg = new StringBuilder(message)
+                    .append("expected was: \"")
+                    .append(expected)
+                    .append("\", but actual was: \"")
+                    .append(actual)
+                    .append("\" [WARNING - not using a delta duration, comparing two instants directly]");
+
+            if (expected != null && actual != null) {
+                if (expected.getMillis() == actual.getMillis()) {
+                    if (EXACT_MILLIS_GOOD_ENOUGH) return;
+
+                    if (org.joda.time.field.FieldUtils.equals(expected.getChronology(), actual.getChronology())) return;
+                    failMsg.append("; Chronologies: ")
+                            .append(expected.getChronology()).append(" vs. ")
+                            .append(actual.getChronology());
+                } else {
+                    failMsg.append("; Millis: ").append(expected.getMillis())
+                            .append(" vs. ").append(actual.getMillis());
+                }
+            }
+
+            if (expected.getChronology() != null && actual.getChronology() != null) {
+                if (expected.getChronology().getZone().getOffset(0) == actual.getChronology().getZone().getOffset(0)) return;
+                failMsg.append("; Chronology offsets: ")
+                        .append(expected.getChronology().getZone().getOffset(0))
+                        .append(" vs. ")
+                        .append(actual.getChronology().getZone().getOffset(0));
+            } else {
+                failMsg.append("; One of the chronologies is null. ");
+            }
+
+            Assert.fail(failMsg.toString());
+        }
+
+        if (expected.isBefore(actual) && expected.plus(delta).isAfter(actual)) return;
+        Assert.fail(message + "expected was \"" + expected + "\", but actual was \"" + actual + "\" (using delta duration of \"" + delta + "\")");
+    }
+
+    static void assertOneEquals(final String message, final org.joda.time.DateTime expected, final org.joda.time.DateTime actual, final org.joda.time.Duration delta) {
+        if (expected == null) Assert.fail(message + "expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        if (expected == actual) return;
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual, delta);
+    }
+
+    public static void assertOneEquals(final org.joda.time.DateTime expected, final org.joda.time.DateTime actual, final org.joda.time.Duration delta) {
+        assertOneEquals("OneTimestamp mismatch: ", expected, actual, delta);
+    }
+
+    public static void assertOneEquals(final org.joda.time.DateTime expected, final org.joda.time.DateTime actual) {
+        assertOneEquals(expected, actual, org.joda.time.Duration.ZERO);
+    }
+
+    private static void assertNullableEquals(final String message, final org.joda.time.DateTime expected, final org.joda.time.DateTime actual, final org.joda.time.Duration delta) {
+        if (expected == actual) return;
+        if (expected == null) Assert.fail(message + "expected was <null>, but actual was \"" + actual + "\"");
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual, delta);
+    }
+
+    public static void assertNullableEquals(final org.joda.time.DateTime expected, final org.joda.time.DateTime actual, final org.joda.time.Duration delta) {
+        assertNullableEquals("NullableTimestamp mismatch: ", expected, actual, delta);
+    }
+
+    public static void assertNullableEquals(final org.joda.time.DateTime expected, final org.joda.time.DateTime actual) {
+        assertNullableEquals(expected, actual, org.joda.time.Duration.ZERO);
+    }
+
+    private static void assertArrayOfOneEquals(final String message, final org.joda.time.DateTime[] expecteds, final org.joda.time.DateTime[] actuals, final org.joda.time.Duration delta) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i], delta);
+        }
+    }
+
+    private static void assertOneArrayOfOneEquals(final String message, final org.joda.time.DateTime[] expecteds, final org.joda.time.DateTime[] actuals, final org.joda.time.Duration delta) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        for (int i = 0; i < expecteds.length; i ++) {
+            if (expecteds[i] == null) {
+                Assert.fail(message + "expecteds contained a <null> element at index " + i + " - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+            }
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals, delta);
+    }
+
+    public static void assertOneArrayOfOneEquals(final org.joda.time.DateTime[] expecteds, final org.joda.time.DateTime[] actuals, final org.joda.time.Duration delta) {
+        assertOneArrayOfOneEquals("OneArrayOfOneTimestamp mismatch: ", expecteds, actuals, delta);
+    }
+
+    public static void assertOneArrayOfOneEquals(final org.joda.time.DateTime[] expecteds, final org.joda.time.DateTime[] actuals) {
+        assertOneArrayOfOneEquals(expecteds, actuals, org.joda.time.Duration.ZERO);
+    }
+
+    private static void assertNullableArrayOfOneEquals(final String message, final org.joda.time.DateTime[] expecteds, final org.joda.time.DateTime[] actuals, final org.joda.time.Duration delta) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals, delta);
+    }
+
+    public static void assertNullableArrayOfOneEquals(final org.joda.time.DateTime[] expecteds, final org.joda.time.DateTime[] actuals, final org.joda.time.Duration delta) {
+        assertNullableArrayOfOneEquals("NullableArrayOfOneTimestamp mismatch: ", expecteds, actuals, delta);
+    }
+
+    public static void assertNullableArrayOfOneEquals(final org.joda.time.DateTime[] expecteds, final org.joda.time.DateTime[] actuals) {
+        assertNullableArrayOfOneEquals(expecteds, actuals, org.joda.time.Duration.ZERO);
+    }
+
+    private static void assertArrayOfNullableEquals(final String message, final org.joda.time.DateTime[] expecteds, final org.joda.time.DateTime[] actuals, final org.joda.time.Duration delta) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i], delta);
+        }
+    }
+
+    private static void assertOneArrayOfNullableEquals(final String message, final org.joda.time.DateTime[] expecteds, final org.joda.time.DateTime[] actuals, final org.joda.time.Duration delta) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals, delta);
+    }
+
+    public static void assertOneArrayOfNullableEquals(final org.joda.time.DateTime[] expecteds, final org.joda.time.DateTime[] actuals, final org.joda.time.Duration delta) {
+        assertOneArrayOfNullableEquals("OneArrayOfNullableTimestamp mismatch: ", expecteds, actuals, delta);
+    }
+
+    public static void assertOneArrayOfNullableEquals(final org.joda.time.DateTime[] expecteds, final org.joda.time.DateTime[] actuals) {
+        assertOneArrayOfNullableEquals(expecteds, actuals, org.joda.time.Duration.ZERO);
+    }
+
+    private static void assertNullableArrayOfNullableEquals(final String message, final org.joda.time.DateTime[] expecteds, final org.joda.time.DateTime[] actuals, final org.joda.time.Duration delta) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals, delta);
+    }
+
+    public static void assertNullableArrayOfNullableEquals(final org.joda.time.DateTime[] expecteds, final org.joda.time.DateTime[] actuals, final org.joda.time.Duration delta) {
+        assertNullableArrayOfNullableEquals("NullableArrayOfNullableTimestamp mismatch: ", expecteds, actuals, delta);
+    }
+
+    public static void assertNullableArrayOfNullableEquals(final org.joda.time.DateTime[] expecteds, final org.joda.time.DateTime[] actuals) {
+        assertNullableArrayOfNullableEquals(expecteds, actuals, org.joda.time.Duration.ZERO);
+    }
+
+    private static void assertListOfOneEquals(final String message, final java.util.List<org.joda.time.DateTime> expecteds, final java.util.List<org.joda.time.DateTime> actuals, final org.joda.time.Duration delta) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<org.joda.time.DateTime> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<org.joda.time.DateTime> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final org.joda.time.DateTime expected = expectedsIterator.next();
+            final org.joda.time.DateTime actual = actualsIterator.next();
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual, delta);
+        }
+    }
+
+    private static void assertOneListOfOneEquals(final String message, final java.util.List<org.joda.time.DateTime> expecteds, final java.util.List<org.joda.time.DateTime> actuals, final org.joda.time.Duration delta) {
+        int i = 0;
+        for (final org.joda.time.DateTime expected : expecteds) {
+            if (expected == null) {
+                Assert.fail(message + "element mismatch occurred at index " + i + ": expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+            }
+            i++;
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals, delta);
+    }
+
+    public static void assertOneListOfOneEquals(final java.util.List<org.joda.time.DateTime> expecteds, final java.util.List<org.joda.time.DateTime> actuals, final org.joda.time.Duration delta) {
+        assertOneListOfOneEquals("OneListOfOneTimestamp mismatch: ", expecteds, actuals, delta);
+    }
+
+    public static void assertOneListOfOneEquals(final java.util.List<org.joda.time.DateTime> expecteds, final java.util.List<org.joda.time.DateTime> actuals) {
+        assertOneListOfOneEquals(expecteds, actuals, org.joda.time.Duration.ZERO);
+    }
+
+    private static void assertNullableListOfOneEquals(final String message, final java.util.List<org.joda.time.DateTime> expecteds, final java.util.List<org.joda.time.DateTime> actuals, final org.joda.time.Duration delta) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals, delta);
+    }
+
+    public static void assertNullableListOfOneEquals(final java.util.List<org.joda.time.DateTime> expecteds, final java.util.List<org.joda.time.DateTime> actuals, final org.joda.time.Duration delta) {
+        assertNullableListOfOneEquals("NullableListOfOneTimestamp mismatch: ", expecteds, actuals, delta);
+    }
+
+    public static void assertNullableListOfOneEquals(final java.util.List<org.joda.time.DateTime> expecteds, final java.util.List<org.joda.time.DateTime> actuals) {
+        assertNullableListOfOneEquals(expecteds, actuals, org.joda.time.Duration.ZERO);
+    }
+
+    private static void assertListOfNullableEquals(final String message, final java.util.List<org.joda.time.DateTime> expecteds, final java.util.List<org.joda.time.DateTime> actuals, final org.joda.time.Duration delta) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<org.joda.time.DateTime> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<org.joda.time.DateTime> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final org.joda.time.DateTime expected = expectedsIterator.next();
+            final org.joda.time.DateTime actual = actualsIterator.next();
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual, delta);
+        }
+    }
+
+    private static void assertOneListOfNullableEquals(final String message, final java.util.List<org.joda.time.DateTime> expecteds, final java.util.List<org.joda.time.DateTime> actuals, final org.joda.time.Duration delta) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals, delta);
+    }
+
+    public static void assertOneListOfNullableEquals(final java.util.List<org.joda.time.DateTime> expecteds, final java.util.List<org.joda.time.DateTime> actuals, final org.joda.time.Duration delta) {
+        assertOneListOfNullableEquals("OneListOfNullableTimestamp mismatch: ", expecteds, actuals, delta);
+    }
+
+    public static void assertOneListOfNullableEquals(final java.util.List<org.joda.time.DateTime> expecteds, final java.util.List<org.joda.time.DateTime> actuals) {
+        assertOneListOfNullableEquals(expecteds, actuals, org.joda.time.Duration.ZERO);
+    }
+
+    private static void assertNullableListOfNullableEquals(final String message, final java.util.List<org.joda.time.DateTime> expecteds, final java.util.List<org.joda.time.DateTime> actuals, final org.joda.time.Duration delta) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals, delta);
+    }
+
+    public static void assertNullableListOfNullableEquals(final java.util.List<org.joda.time.DateTime> expecteds, final java.util.List<org.joda.time.DateTime> actuals, final org.joda.time.Duration delta) {
+        assertNullableListOfNullableEquals("NullableListOfNullableTimestamp mismatch: ", expecteds, actuals, delta);
+    }
+
+    public static void assertNullableListOfNullableEquals(final java.util.List<org.joda.time.DateTime> expecteds, final java.util.List<org.joda.time.DateTime> actuals) {
+        assertNullableListOfNullableEquals(expecteds, actuals, org.joda.time.Duration.ZERO);
+    }
+
+    private static void assertSetOfOneEquals(final String message, final java.util.Set<org.joda.time.DateTime> expecteds, final java.util.Set<org.joda.time.DateTime> actuals, final org.joda.time.Duration delta) {
+        if (actuals.contains(null)) {
+            Assert.fail(message + "actuals contained a <null> element");
+        }
+
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        expectedsLoop: for (final org.joda.time.DateTime expected : expecteds) {
+            if (actuals.contains(expected)) continue;
+            for (final org.joda.time.DateTime actual : actuals) {
+                try {
+                    assertOneEquals(expected, actual, delta);
+                    continue expectedsLoop;
+                }
+                catch (final AssertionError e) {}
+            }
+            Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+        }
+    }
+
+    private static void assertOneSetOfOneEquals(final String message, final java.util.Set<org.joda.time.DateTime> expecteds, final java.util.Set<org.joda.time.DateTime> actuals, final org.joda.time.Duration delta) {
+        if (expecteds.contains(null)) {
+            Assert.fail(message + "expecteds contained a <null> element - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals, delta);
+    }
+
+    public static void assertOneSetOfOneEquals(final java.util.Set<org.joda.time.DateTime> expecteds, final java.util.Set<org.joda.time.DateTime> actuals, final org.joda.time.Duration delta) {
+        assertOneSetOfOneEquals("OneSetOfOneTimestamp mismatch: ", expecteds, actuals, delta);
+    }
+
+    public static void assertOneSetOfOneEquals(final java.util.Set<org.joda.time.DateTime> expecteds, final java.util.Set<org.joda.time.DateTime> actuals) {
+        assertOneSetOfOneEquals(expecteds, actuals, org.joda.time.Duration.ZERO);
+    }
+
+    private static void assertNullableSetOfOneEquals(final String message, final java.util.Set<org.joda.time.DateTime> expecteds, final java.util.Set<org.joda.time.DateTime> actuals, final org.joda.time.Duration delta) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals, delta);
+    }
+
+    public static void assertNullableSetOfOneEquals(final java.util.Set<org.joda.time.DateTime> expecteds, final java.util.Set<org.joda.time.DateTime> actuals, final org.joda.time.Duration delta) {
+        assertNullableSetOfOneEquals("NullableSetOfOneTimestamp mismatch: ", expecteds, actuals, delta);
+    }
+
+    public static void assertNullableSetOfOneEquals(final java.util.Set<org.joda.time.DateTime> expecteds, final java.util.Set<org.joda.time.DateTime> actuals) {
+        assertNullableSetOfOneEquals(expecteds, actuals, org.joda.time.Duration.ZERO);
+    }
+
+    private static void assertSetOfNullableEquals(final String message, final java.util.Set<org.joda.time.DateTime> expecteds, final java.util.Set<org.joda.time.DateTime> actuals, final org.joda.time.Duration delta) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        expectedsLoop: for (final org.joda.time.DateTime expected : expecteds) {
+            if (actuals.contains(expected)) continue;
+            for (final org.joda.time.DateTime actual : actuals) {
+                try {
+                    assertNullableEquals(expected, actual, delta);
+                    continue expectedsLoop;
+                }
+                catch (final AssertionError e) {}
+            }
+            Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+        }
+    }
+
+    private static void assertOneSetOfNullableEquals(final String message, final java.util.Set<org.joda.time.DateTime> expecteds, final java.util.Set<org.joda.time.DateTime> actuals, final org.joda.time.Duration delta) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals, delta);
+    }
+
+    public static void assertOneSetOfNullableEquals(final java.util.Set<org.joda.time.DateTime> expecteds, final java.util.Set<org.joda.time.DateTime> actuals, final org.joda.time.Duration delta) {
+        assertOneSetOfNullableEquals("OneSetOfNullableTimestamp mismatch: ", expecteds, actuals, delta);
+    }
+
+    public static void assertOneSetOfNullableEquals(final java.util.Set<org.joda.time.DateTime> expecteds, final java.util.Set<org.joda.time.DateTime> actuals) {
+        assertOneSetOfNullableEquals(expecteds, actuals, org.joda.time.Duration.ZERO);
+    }
+
+    private static void assertNullableSetOfNullableEquals(final String message, final java.util.Set<org.joda.time.DateTime> expecteds, final java.util.Set<org.joda.time.DateTime> actuals, final org.joda.time.Duration delta) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals, delta);
+    }
+
+    public static void assertNullableSetOfNullableEquals(final java.util.Set<org.joda.time.DateTime> expecteds, final java.util.Set<org.joda.time.DateTime> actuals, final org.joda.time.Duration delta) {
+        assertNullableSetOfNullableEquals("NullableSetOfNullableTimestamp mismatch: ", expecteds, actuals, delta);
+    }
+
+    public static void assertNullableSetOfNullableEquals(final java.util.Set<org.joda.time.DateTime> expecteds, final java.util.Set<org.joda.time.DateTime> actuals) {
+        assertNullableSetOfNullableEquals(expecteds, actuals, org.joda.time.Duration.ZERO);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/UrlAsserts.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/UrlAsserts.java
@@ -1,0 +1,261 @@
+package com.dslplatform.ocd.javaasserts;
+
+import org.junit.Assert;
+
+public class UrlAsserts {
+    static void assertSingleEquals(final String message, final java.net.URI expected, final java.net.URI actual) {
+        if (expected.equals(actual)) return;
+        Assert.fail(message + "expected was \"" + expected + "\", but actual was \"" + actual + "\"");
+    }
+
+    static void assertOneEquals(final String message, final java.net.URI expected, final java.net.URI actual) {
+        if (expected == null) Assert.fail(message + "expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        if (expected == actual) return;
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertOneEquals(final java.net.URI expected, final java.net.URI actual) {
+        assertOneEquals("OneUrl mismatch: ", expected, actual);
+    }
+
+    private static void assertNullableEquals(final String message, final java.net.URI expected, final java.net.URI actual) {
+        if (expected == actual) return;
+        if (expected == null) Assert.fail(message + "expected was <null>, but actual was \"" + actual + "\"");
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertNullableEquals(final java.net.URI expected, final java.net.URI actual) {
+        assertNullableEquals("NullableUrl mismatch: ", expected, actual);
+    }
+
+    private static void assertArrayOfOneEquals(final String message, final java.net.URI[] expecteds, final java.net.URI[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfOneEquals(final String message, final java.net.URI[] expecteds, final java.net.URI[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        for (int i = 0; i < expecteds.length; i ++) {
+            if (expecteds[i] == null) {
+                Assert.fail(message + "expecteds contained a <null> element at index " + i + " - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+            }
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfOneEquals(final java.net.URI[] expecteds, final java.net.URI[] actuals) {
+        assertOneArrayOfOneEquals("OneArrayOfOneUrl mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfOneEquals(final String message, final java.net.URI[] expecteds, final java.net.URI[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfOneEquals(final java.net.URI[] expecteds, final java.net.URI[] actuals) {
+        assertNullableArrayOfOneEquals("NullableArrayOfOneUrl mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertArrayOfNullableEquals(final String message, final java.net.URI[] expecteds, final java.net.URI[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfNullableEquals(final String message, final java.net.URI[] expecteds, final java.net.URI[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfNullableEquals(final java.net.URI[] expecteds, final java.net.URI[] actuals) {
+        assertOneArrayOfNullableEquals("OneArrayOfNullableUrl mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfNullableEquals(final String message, final java.net.URI[] expecteds, final java.net.URI[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfNullableEquals(final java.net.URI[] expecteds, final java.net.URI[] actuals) {
+        assertNullableArrayOfNullableEquals("NullableArrayOfNullableUrl mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfOneEquals(final String message, final java.util.List<java.net.URI> expecteds, final java.util.List<java.net.URI> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<java.net.URI> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<java.net.URI> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final java.net.URI expected = expectedsIterator.next();
+            final java.net.URI actual = actualsIterator.next();
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfOneEquals(final String message, final java.util.List<java.net.URI> expecteds, final java.util.List<java.net.URI> actuals) {
+        int i = 0;
+        for (final java.net.URI expected : expecteds) {
+            if (expected == null) {
+                Assert.fail(message + "element mismatch occurred at index " + i + ": expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+            }
+            i++;
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfOneEquals(final java.util.List<java.net.URI> expecteds, final java.util.List<java.net.URI> actuals) {
+        assertOneListOfOneEquals("OneListOfOneUrl mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfOneEquals(final String message, final java.util.List<java.net.URI> expecteds, final java.util.List<java.net.URI> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfOneEquals(final java.util.List<java.net.URI> expecteds, final java.util.List<java.net.URI> actuals) {
+        assertNullableListOfOneEquals("NullableListOfOneUrl mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfNullableEquals(final String message, final java.util.List<java.net.URI> expecteds, final java.util.List<java.net.URI> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<java.net.URI> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<java.net.URI> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final java.net.URI expected = expectedsIterator.next();
+            final java.net.URI actual = actualsIterator.next();
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfNullableEquals(final String message, final java.util.List<java.net.URI> expecteds, final java.util.List<java.net.URI> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfNullableEquals(final java.util.List<java.net.URI> expecteds, final java.util.List<java.net.URI> actuals) {
+        assertOneListOfNullableEquals("OneListOfNullableUrl mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfNullableEquals(final String message, final java.util.List<java.net.URI> expecteds, final java.util.List<java.net.URI> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfNullableEquals(final java.util.List<java.net.URI> expecteds, final java.util.List<java.net.URI> actuals) {
+        assertNullableListOfNullableEquals("NullableListOfNullableUrl mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfOneEquals(final String message, final java.util.Set<java.net.URI> expecteds, final java.util.Set<java.net.URI> actuals) {
+        if (actuals.contains(null)) {
+            Assert.fail(message + "actuals contained a <null> element");
+        }
+
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        for (final java.net.URI expected : expecteds) {
+            if (!actuals.contains(expected)) {
+                Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+            }
+        }
+    }
+
+    private static void assertOneSetOfOneEquals(final String message, final java.util.Set<java.net.URI> expecteds, final java.util.Set<java.net.URI> actuals) {
+        if (expecteds.contains(null)) {
+            Assert.fail(message + "expecteds contained a <null> element - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfOneEquals(final java.util.Set<java.net.URI> expecteds, final java.util.Set<java.net.URI> actuals) {
+        assertOneSetOfOneEquals("OneSetOfOneUrl mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfOneEquals(final String message, final java.util.Set<java.net.URI> expecteds, final java.util.Set<java.net.URI> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfOneEquals(final java.util.Set<java.net.URI> expecteds, final java.util.Set<java.net.URI> actuals) {
+        assertNullableSetOfOneEquals("NullableSetOfOneUrl mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfNullableEquals(final String message, final java.util.Set<java.net.URI> expecteds, final java.util.Set<java.net.URI> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        for (final java.net.URI expected : expecteds) {
+            if (!actuals.contains(expected)) {
+                Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+            }
+        }
+    }
+
+    private static void assertOneSetOfNullableEquals(final String message, final java.util.Set<java.net.URI> expecteds, final java.util.Set<java.net.URI> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfNullableEquals(final java.util.Set<java.net.URI> expecteds, final java.util.Set<java.net.URI> actuals) {
+        assertOneSetOfNullableEquals("OneSetOfNullableUrl mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfNullableEquals(final String message, final java.util.Set<java.net.URI> expecteds, final java.util.Set<java.net.URI> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfNullableEquals(final java.util.Set<java.net.URI> expecteds, final java.util.Set<java.net.URI> actuals) {
+        assertNullableSetOfNullableEquals("NullableSetOfNullableUrl mismatch: ", expecteds, actuals);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/XmlAsserts.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/javaasserts/XmlAsserts.java
@@ -1,0 +1,278 @@
+package com.dslplatform.ocd.javaasserts;
+
+import org.junit.Assert;
+
+public class XmlAsserts {
+    static void assertSingleEquals(final String message, final org.w3c.dom.Element expected, final org.w3c.dom.Element actual) {
+        if (expected == actual) return;
+
+        final String expectedString = com.dslplatform.ocd.test.Utils.elementToString(expected);
+        final String actualString = com.dslplatform.ocd.test.Utils.elementToString(actual);
+
+        if (expectedString.equals(actualString)) return;
+        Assert.fail(message + "expected was \"" + expectedString + "\", but actual was \"" + actualString + "\"");
+    }
+
+    static void assertOneEquals(final String message, final org.w3c.dom.Element expected, final org.w3c.dom.Element actual) {
+        if (expected == null) Assert.fail(message + "expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        if (expected == actual) return;
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertOneEquals(final org.w3c.dom.Element expected, final org.w3c.dom.Element actual) {
+        assertOneEquals("OneXml mismatch: ", expected, actual);
+    }
+
+    private static void assertNullableEquals(final String message, final org.w3c.dom.Element expected, final org.w3c.dom.Element actual) {
+        if (expected == actual) return;
+        if (expected == null) Assert.fail(message + "expected was <null>, but actual was \"" + actual + "\"");
+        if (actual == null) Assert.fail(message + "expected was \"" + expected + "\", but actual was <null>");
+        assertSingleEquals(message, expected, actual);
+    }
+
+    public static void assertNullableEquals(final org.w3c.dom.Element expected, final org.w3c.dom.Element actual) {
+        assertNullableEquals("NullableXml mismatch: ", expected, actual);
+    }
+
+    private static void assertArrayOfOneEquals(final String message, final org.w3c.dom.Element[] expecteds, final org.w3c.dom.Element[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfOneEquals(final String message, final org.w3c.dom.Element[] expecteds, final org.w3c.dom.Element[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        for (int i = 0; i < expecteds.length; i ++) {
+            if (expecteds[i] == null) {
+                Assert.fail(message + "expecteds contained a <null> element at index " + i + " - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+            }
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfOneEquals(final org.w3c.dom.Element[] expecteds, final org.w3c.dom.Element[] actuals) {
+        assertOneArrayOfOneEquals("OneArrayOfOneXml mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfOneEquals(final String message, final org.w3c.dom.Element[] expecteds, final org.w3c.dom.Element[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfOneEquals(final org.w3c.dom.Element[] expecteds, final org.w3c.dom.Element[] actuals) {
+        assertNullableArrayOfOneEquals("NullableArrayOfOneXml mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertArrayOfNullableEquals(final String message, final org.w3c.dom.Element[] expecteds, final org.w3c.dom.Element[] actuals) {
+        if (expecteds.length != actuals.length) {
+            Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was an array of length " + actuals.length);
+        }
+
+        for (int i = 0; i < expecteds.length; i++) {
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expecteds[i], actuals[i]);
+        }
+    }
+
+    private static void assertOneArrayOfNullableEquals(final String message, final org.w3c.dom.Element[] expecteds, final org.w3c.dom.Element[] actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneArrayOfNullableEquals(final org.w3c.dom.Element[] expecteds, final org.w3c.dom.Element[] actuals) {
+        assertOneArrayOfNullableEquals("OneArrayOfNullableXml mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableArrayOfNullableEquals(final String message, final org.w3c.dom.Element[] expecteds, final org.w3c.dom.Element[] actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was an array of length " + actuals.length);
+        if (actuals == null) Assert.fail(message + " expecteds was an array of length " + expecteds.length + ", but actuals was <null>");
+        assertArrayOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableArrayOfNullableEquals(final org.w3c.dom.Element[] expecteds, final org.w3c.dom.Element[] actuals) {
+        assertNullableArrayOfNullableEquals("NullableArrayOfNullableXml mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfOneEquals(final String message, final java.util.List<org.w3c.dom.Element> expecteds, final java.util.List<org.w3c.dom.Element> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<org.w3c.dom.Element> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<org.w3c.dom.Element> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final org.w3c.dom.Element expected = expectedsIterator.next();
+            final org.w3c.dom.Element actual = actualsIterator.next();
+            assertOneEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfOneEquals(final String message, final java.util.List<org.w3c.dom.Element> expecteds, final java.util.List<org.w3c.dom.Element> actuals) {
+        int i = 0;
+        for (final org.w3c.dom.Element expected : expecteds) {
+            if (expected == null) {
+                Assert.fail(message + "element mismatch occurred at index " + i + ": expected was <null> - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+            }
+            i++;
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfOneEquals(final java.util.List<org.w3c.dom.Element> expecteds, final java.util.List<org.w3c.dom.Element> actuals) {
+        assertOneListOfOneEquals("OneListOfOneXml mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfOneEquals(final String message, final java.util.List<org.w3c.dom.Element> expecteds, final java.util.List<org.w3c.dom.Element> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfOneEquals(final java.util.List<org.w3c.dom.Element> expecteds, final java.util.List<org.w3c.dom.Element> actuals) {
+        assertNullableListOfOneEquals("NullableListOfOneXml mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertListOfNullableEquals(final String message, final java.util.List<org.w3c.dom.Element> expecteds, final java.util.List<org.w3c.dom.Element> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a list of size " + expectedsSize + ", but actuals was a list of size " + actualsSize);
+        }
+
+        final java.util.Iterator<org.w3c.dom.Element> expectedsIterator = expecteds.iterator();
+        final java.util.Iterator<org.w3c.dom.Element> actualsIterator = actuals.iterator();
+        for (int i = 0; i < expectedsSize; i++) {
+            final org.w3c.dom.Element expected = expectedsIterator.next();
+            final org.w3c.dom.Element actual = actualsIterator.next();
+            assertNullableEquals(message + "element mismatch occurred at index " + i + ": ", expected, actual);
+        }
+    }
+
+    private static void assertOneListOfNullableEquals(final String message, final java.util.List<org.w3c.dom.Element> expecteds, final java.util.List<org.w3c.dom.Element> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneListOfNullableEquals(final java.util.List<org.w3c.dom.Element> expecteds, final java.util.List<org.w3c.dom.Element> actuals) {
+        assertOneListOfNullableEquals("OneListOfNullableXml mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableListOfNullableEquals(final String message, final java.util.List<org.w3c.dom.Element> expecteds, final java.util.List<org.w3c.dom.Element> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a list of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a list of size " + expecteds.size() + ", but actuals was <null>");
+        assertListOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableListOfNullableEquals(final java.util.List<org.w3c.dom.Element> expecteds, final java.util.List<org.w3c.dom.Element> actuals) {
+        assertNullableListOfNullableEquals("NullableListOfNullableXml mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfOneEquals(final String message, final java.util.Set<org.w3c.dom.Element> expecteds, final java.util.Set<org.w3c.dom.Element> actuals) {
+        if (actuals.contains(null)) {
+            Assert.fail(message + "actuals contained a <null> element");
+        }
+
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        expectedsLoop: for (final org.w3c.dom.Element expected : expecteds) {
+            if (actuals.contains(expected)) continue;
+            for (final org.w3c.dom.Element actual : actuals) {
+                try {
+                    assertOneEquals(expected, actual);
+                    continue expectedsLoop;
+                }
+                catch (final AssertionError e) {}
+            }
+            Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+        }
+    }
+
+    private static void assertOneSetOfOneEquals(final String message, final java.util.Set<org.w3c.dom.Element> expecteds, final java.util.Set<org.w3c.dom.Element> actuals) {
+        if (expecteds.contains(null)) {
+            Assert.fail(message + "expecteds contained a <null> element - WARNING: This is a preconditions failure in expected, this assertion will never succeed!");
+        }
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfOneEquals(final java.util.Set<org.w3c.dom.Element> expecteds, final java.util.Set<org.w3c.dom.Element> actuals) {
+        assertOneSetOfOneEquals("OneSetOfOneXml mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfOneEquals(final String message, final java.util.Set<org.w3c.dom.Element> expecteds, final java.util.Set<org.w3c.dom.Element> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfOneEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfOneEquals(final java.util.Set<org.w3c.dom.Element> expecteds, final java.util.Set<org.w3c.dom.Element> actuals) {
+        assertNullableSetOfOneEquals("NullableSetOfOneXml mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertSetOfNullableEquals(final String message, final java.util.Set<org.w3c.dom.Element> expecteds, final java.util.Set<org.w3c.dom.Element> actuals) {
+        final int expectedsSize = expecteds.size();
+        final int actualsSize = actuals.size();
+        if (expectedsSize != actualsSize) {
+            Assert.fail(message + "expecteds was a set of size " + expectedsSize + ", but actuals was a set of size " + actualsSize);
+        }
+
+        expectedsLoop: for (final org.w3c.dom.Element expected : expecteds) {
+            if (actuals.contains(expected)) continue;
+            for (final org.w3c.dom.Element actual : actuals) {
+                try {
+                    assertNullableEquals(expected, actual);
+                    continue expectedsLoop;
+                }
+                catch (final AssertionError e) {}
+            }
+            Assert.fail(message + "actuals did not contain the expecteds element \"" + expected + "\"");
+        }
+    }
+
+    private static void assertOneSetOfNullableEquals(final String message, final java.util.Set<org.w3c.dom.Element> expecteds, final java.util.Set<org.w3c.dom.Element> actuals) {
+        if (expecteds == null) Assert.fail(message + "expecteds was <null> - WARNING: This is a preconditions failure in expecteds, this assertion will never succeed!");
+        if (expecteds == actuals) return;
+        if (actuals == null) Assert.fail(message + "expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertOneSetOfNullableEquals(final java.util.Set<org.w3c.dom.Element> expecteds, final java.util.Set<org.w3c.dom.Element> actuals) {
+        assertOneSetOfNullableEquals("OneSetOfNullableXml mismatch: ", expecteds, actuals);
+    }
+
+    private static void assertNullableSetOfNullableEquals(final String message, final java.util.Set<org.w3c.dom.Element> expecteds, final java.util.Set<org.w3c.dom.Element> actuals) {
+        if (expecteds == actuals) return;
+        if (expecteds == null) Assert.fail(message + "expecteds was <null>, but actuals was a set of size " + actuals.size());
+        if (actuals == null) Assert.fail(message + " expecteds was a set of size " + expecteds.size() + ", but actuals was <null>");
+        assertSetOfNullableEquals(message, expecteds, actuals);
+    }
+
+    public static void assertNullableSetOfNullableEquals(final java.util.Set<org.w3c.dom.Element> expecteds, final java.util.Set<org.w3c.dom.Element> actuals) {
+        assertNullableSetOfNullableEquals("NullableSetOfNullableXml mismatch: ", expecteds, actuals);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/TypeFactory.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/TypeFactory.java
@@ -1,0 +1,24 @@
+package com.dslplatform.ocd.test;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+
+public abstract class TypeFactory {
+    public static URI buildURI(final String uri) {
+        try {
+            return new URI(uri);
+        } catch (final URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static InetAddress buildIP(final String ip) {
+        try {
+            return InetAddress.getByName(ip);
+        } catch (final UnknownHostException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/Utils.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/Utils.java
@@ -1,0 +1,21 @@
+package com.dslplatform.ocd.test;
+
+import org.w3c.dom.Element;
+
+public abstract class Utils {
+    public static Element stringToElement(final String element) {
+        try {
+            return XMLConverter.INSTANCE.stringToDocument(element).getDocumentElement();
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String elementToString(final Element element) {
+        try {
+            return XMLConverter.INSTANCE.nodeToString(element);
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/XMLConverter.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/XMLConverter.java
@@ -1,0 +1,83 @@
+package com.dslplatform.ocd.test;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+public enum XMLConverter {
+    INSTANCE;
+
+    private final ThreadLocal<DocumentBuilder> documentBuilder = new ThreadLocal<DocumentBuilder>() {
+        @Override
+        protected DocumentBuilder initialValue() {
+            try {
+                final DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+                dbf.setValidating(false);
+                dbf.setFeature("http://xml.org/sax/features/namespaces", false);
+                dbf.setFeature("http://xml.org/sax/features/validation", false);
+                dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-dtd-grammar", false);
+                dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+                dbf.setNamespaceAware(false);
+                dbf.newDocumentBuilder();
+                return dbf.newDocumentBuilder();
+            } catch (final Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    };
+
+    private final ThreadLocal<Transformer> transformer = new ThreadLocal<Transformer>() {
+        @Override
+        protected Transformer initialValue() {
+            try {
+                final TransformerFactory tf = TransformerFactory.newInstance();
+                final Transformer transformer = tf.newTransformer();
+                transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+                transformer.setOutputProperty(OutputKeys.INDENT, "no");
+                return transformer;
+            } catch (final Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    };
+
+    /**
+     * Converts a <code>String</code> into a <code>org.w3c.dom.Document</code>.
+     * Use a <code>ThreadLocal</code> instance of the
+     * <code>DocumentBuilderFactory</code> to prevent the FWK005 parsing while
+     * parsing exception when being used by concurrent threads.
+     *
+     * @throws IOException
+     * @throws SAXException
+     */
+    public Document stringToDocument(final String xml) throws SAXException, IOException {
+        return documentBuilder.get().parse(new InputSource(new StringReader(xml)));
+    }
+
+    /**
+     * Converts a <code>org.w3c.dom.Node</code> into a <code>String</code> Use a
+     * <code>ThreadLocal</code> instance of the <code>Transformer</code> to
+     * prevent potential concurrency exceptions.
+     *
+     * @throws TransformerException
+     */
+    public String nodeToString(final Node node) throws TransformerException {
+        final StringWriter sw = new StringWriter();
+        transformer.get().transform(new DOMSource(node), new StreamResult(sw));
+        return sw.toString();
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Binary/NullableArrayOfNullableBinariesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Binary/NullableArrayOfNullableBinariesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Binary;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfNullableBinariesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final byte[][] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final byte[][] defaultValueJsonDeserialized = jsonSerialization.deserialize(byte[][].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final byte[][] borderValue1 = new byte[][] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final byte[][] borderValue1JsonDeserialized = jsonSerialization.deserialize(byte[][].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final byte[][] borderValue2 = new byte[][] { new byte[0] };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final byte[][] borderValue2JsonDeserialized = jsonSerialization.deserialize(byte[][].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final byte[][] borderValue3 = new byte[][] { new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE } };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final byte[][] borderValue3JsonDeserialized = jsonSerialization.deserialize(byte[][].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final byte[][] borderValue4 = new byte[][] { new byte[0], new byte[] { Byte.MIN_VALUE }, new byte[] { Byte.MIN_VALUE, 0 }, new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE } };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final byte[][] borderValue4JsonDeserialized = jsonSerialization.deserialize(byte[][].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final byte[][] borderValue5 = new byte[][] { null, new byte[0], new byte[] { Byte.MIN_VALUE }, new byte[] { Byte.MIN_VALUE, 0 }, new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE } };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final byte[][] borderValue5JsonDeserialized = jsonSerialization.deserialize(byte[][].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Binary/NullableArrayOfOneBinariesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Binary/NullableArrayOfOneBinariesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Binary;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfOneBinariesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final byte[][] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final byte[][] defaultValueJsonDeserialized = jsonSerialization.deserialize(byte[][].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final byte[][] borderValue1 = new byte[][] { new byte[0] };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final byte[][] borderValue1JsonDeserialized = jsonSerialization.deserialize(byte[][].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final byte[][] borderValue2 = new byte[][] { new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE } };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final byte[][] borderValue2JsonDeserialized = jsonSerialization.deserialize(byte[][].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final byte[][] borderValue3 = new byte[][] { new byte[0], new byte[] { Byte.MIN_VALUE }, new byte[] { Byte.MIN_VALUE, 0 }, new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE } };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final byte[][] borderValue3JsonDeserialized = jsonSerialization.deserialize(byte[][].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Binary/NullableBinaryDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Binary/NullableBinaryDefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Binary;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableBinaryDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final byte[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final byte[] defaultValueJsonDeserialized = jsonSerialization.deserialize(byte[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final byte[] borderValue1 = new byte[0];
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final byte[] borderValue1JsonDeserialized = jsonSerialization.deserialize(byte[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final byte[] borderValue2 = new byte[] { Byte.MIN_VALUE };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final byte[] borderValue2JsonDeserialized = jsonSerialization.deserialize(byte[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final byte[] borderValue3 = new byte[] { Byte.MIN_VALUE, 0 };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final byte[] borderValue3JsonDeserialized = jsonSerialization.deserialize(byte[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final byte[] borderValue4 = new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final byte[] borderValue4JsonDeserialized = jsonSerialization.deserialize(byte[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Binary/NullableListOfNullableBinariesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Binary/NullableListOfNullableBinariesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Binary;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfNullableBinariesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<byte[]> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<byte[]> defaultValueJsonDeserialized = jsonSerialization.deserializeList(byte[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<byte[]> borderValue1 = new java.util.ArrayList<byte[]>(java.util.Arrays.asList((byte[]) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<byte[]> borderValue1JsonDeserialized = jsonSerialization.deserializeList(byte[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<byte[]> borderValue2 = new java.util.ArrayList<byte[]>(java.util.Arrays.asList(new byte[0]));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<byte[]> borderValue2JsonDeserialized = jsonSerialization.deserializeList(byte[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<byte[]> borderValue3 = new java.util.ArrayList<byte[]>(java.util.Arrays.asList(new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE }));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<byte[]> borderValue3JsonDeserialized = jsonSerialization.deserializeList(byte[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<byte[]> borderValue4 = new java.util.ArrayList<byte[]>(java.util.Arrays.asList(new byte[0], new byte[] { Byte.MIN_VALUE }, new byte[] { Byte.MIN_VALUE, 0 }, new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE }));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<byte[]> borderValue4JsonDeserialized = jsonSerialization.deserializeList(byte[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<byte[]> borderValue5 = new java.util.ArrayList<byte[]>(java.util.Arrays.asList((byte[]) null, new byte[0], new byte[] { Byte.MIN_VALUE }, new byte[] { Byte.MIN_VALUE, 0 }, new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE }));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<byte[]> borderValue5JsonDeserialized = jsonSerialization.deserializeList(byte[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Binary/NullableListOfOneBinariesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Binary/NullableListOfOneBinariesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Binary;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfOneBinariesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<byte[]> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<byte[]> defaultValueJsonDeserialized = jsonSerialization.deserializeList(byte[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<byte[]> borderValue1 = new java.util.ArrayList<byte[]>(java.util.Arrays.asList(new byte[0]));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<byte[]> borderValue1JsonDeserialized = jsonSerialization.deserializeList(byte[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<byte[]> borderValue2 = new java.util.ArrayList<byte[]>(java.util.Arrays.asList(new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE }));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<byte[]> borderValue2JsonDeserialized = jsonSerialization.deserializeList(byte[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<byte[]> borderValue3 = new java.util.ArrayList<byte[]>(java.util.Arrays.asList(new byte[0], new byte[] { Byte.MIN_VALUE }, new byte[] { Byte.MIN_VALUE, 0 }, new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE }));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<byte[]> borderValue3JsonDeserialized = jsonSerialization.deserializeList(byte[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Binary/NullableSetOfNullableBinariesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Binary/NullableSetOfNullableBinariesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Binary;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfNullableBinariesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<byte[]> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<byte[]> defaultValueJsonDeserialized = new java.util.HashSet<byte[]>(jsonSerialization.deserializeList(byte[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<byte[]> borderValue1 = new java.util.HashSet<byte[]>(java.util.Arrays.asList((byte[]) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<byte[]> borderValue1JsonDeserialized = new java.util.HashSet<byte[]>(jsonSerialization.deserializeList(byte[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<byte[]> borderValue2 = new java.util.HashSet<byte[]>(java.util.Arrays.asList(new byte[0]));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<byte[]> borderValue2JsonDeserialized = new java.util.HashSet<byte[]>(jsonSerialization.deserializeList(byte[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<byte[]> borderValue3 = new java.util.HashSet<byte[]>(java.util.Arrays.asList(new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE }));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<byte[]> borderValue3JsonDeserialized = new java.util.HashSet<byte[]>(jsonSerialization.deserializeList(byte[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<byte[]> borderValue4 = new java.util.HashSet<byte[]>(java.util.Arrays.asList(new byte[0], new byte[] { Byte.MIN_VALUE }, new byte[] { Byte.MIN_VALUE, 0 }, new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE }));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<byte[]> borderValue4JsonDeserialized = new java.util.HashSet<byte[]>(jsonSerialization.deserializeList(byte[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<byte[]> borderValue5 = new java.util.HashSet<byte[]>(java.util.Arrays.asList((byte[]) null, new byte[0], new byte[] { Byte.MIN_VALUE }, new byte[] { Byte.MIN_VALUE, 0 }, new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE }));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<byte[]> borderValue5JsonDeserialized = new java.util.HashSet<byte[]>(jsonSerialization.deserializeList(byte[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Binary/NullableSetOfOneBinariesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Binary/NullableSetOfOneBinariesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Binary;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfOneBinariesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<byte[]> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<byte[]> defaultValueJsonDeserialized = new java.util.HashSet<byte[]>(jsonSerialization.deserializeList(byte[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<byte[]> borderValue1 = new java.util.HashSet<byte[]>(java.util.Arrays.asList(new byte[0]));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<byte[]> borderValue1JsonDeserialized = new java.util.HashSet<byte[]>(jsonSerialization.deserializeList(byte[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<byte[]> borderValue2 = new java.util.HashSet<byte[]>(java.util.Arrays.asList(new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE }));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<byte[]> borderValue2JsonDeserialized = new java.util.HashSet<byte[]>(jsonSerialization.deserializeList(byte[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<byte[]> borderValue3 = new java.util.HashSet<byte[]>(java.util.Arrays.asList(new byte[0], new byte[] { Byte.MIN_VALUE }, new byte[] { Byte.MIN_VALUE, 0 }, new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE }));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<byte[]> borderValue3JsonDeserialized = new java.util.HashSet<byte[]>(jsonSerialization.deserializeList(byte[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertNullableSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Binary/OneArrayOfNullableBinariesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Binary/OneArrayOfNullableBinariesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Binary;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfNullableBinariesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final byte[][] defaultValue = new byte[0][];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final byte[][] defaultValueJsonDeserialized = jsonSerialization.deserialize(byte[][].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final byte[][] borderValue1 = new byte[][] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final byte[][] borderValue1JsonDeserialized = jsonSerialization.deserialize(byte[][].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final byte[][] borderValue2 = new byte[][] { new byte[0] };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final byte[][] borderValue2JsonDeserialized = jsonSerialization.deserialize(byte[][].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final byte[][] borderValue3 = new byte[][] { new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE } };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final byte[][] borderValue3JsonDeserialized = jsonSerialization.deserialize(byte[][].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final byte[][] borderValue4 = new byte[][] { new byte[0], new byte[] { Byte.MIN_VALUE }, new byte[] { Byte.MIN_VALUE, 0 }, new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE } };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final byte[][] borderValue4JsonDeserialized = jsonSerialization.deserialize(byte[][].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final byte[][] borderValue5 = new byte[][] { null, new byte[0], new byte[] { Byte.MIN_VALUE }, new byte[] { Byte.MIN_VALUE, 0 }, new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE } };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final byte[][] borderValue5JsonDeserialized = jsonSerialization.deserialize(byte[][].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Binary/OneArrayOfOneBinariesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Binary/OneArrayOfOneBinariesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Binary;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfOneBinariesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final byte[][] defaultValue = new byte[0][];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final byte[][] defaultValueJsonDeserialized = jsonSerialization.deserialize(byte[][].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final byte[][] borderValue1 = new byte[][] { new byte[0] };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final byte[][] borderValue1JsonDeserialized = jsonSerialization.deserialize(byte[][].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final byte[][] borderValue2 = new byte[][] { new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE } };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final byte[][] borderValue2JsonDeserialized = jsonSerialization.deserialize(byte[][].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final byte[][] borderValue3 = new byte[][] { new byte[0], new byte[] { Byte.MIN_VALUE }, new byte[] { Byte.MIN_VALUE, 0 }, new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE } };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final byte[][] borderValue3JsonDeserialized = jsonSerialization.deserialize(byte[][].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Binary/OneBinaryDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Binary/OneBinaryDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Binary;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneBinaryDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final byte[] defaultValue = new byte[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final byte[] defaultValueJsonDeserialized = jsonSerialization.deserialize(byte[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final byte[] borderValue1 = new byte[] { Byte.MIN_VALUE };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final byte[] borderValue1JsonDeserialized = jsonSerialization.deserialize(byte[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final byte[] borderValue2 = new byte[] { Byte.MIN_VALUE, 0 };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final byte[] borderValue2JsonDeserialized = jsonSerialization.deserialize(byte[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final byte[] borderValue3 = new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final byte[] borderValue3JsonDeserialized = jsonSerialization.deserialize(byte[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Binary/OneListOfNullableBinariesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Binary/OneListOfNullableBinariesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Binary;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfNullableBinariesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<byte[]> defaultValue = new java.util.ArrayList<byte[]>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<byte[]> defaultValueJsonDeserialized = jsonSerialization.deserializeList(byte[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<byte[]> borderValue1 = new java.util.ArrayList<byte[]>(java.util.Arrays.asList((byte[]) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<byte[]> borderValue1JsonDeserialized = jsonSerialization.deserializeList(byte[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<byte[]> borderValue2 = new java.util.ArrayList<byte[]>(java.util.Arrays.asList(new byte[0]));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<byte[]> borderValue2JsonDeserialized = jsonSerialization.deserializeList(byte[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<byte[]> borderValue3 = new java.util.ArrayList<byte[]>(java.util.Arrays.asList(new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE }));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<byte[]> borderValue3JsonDeserialized = jsonSerialization.deserializeList(byte[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<byte[]> borderValue4 = new java.util.ArrayList<byte[]>(java.util.Arrays.asList(new byte[0], new byte[] { Byte.MIN_VALUE }, new byte[] { Byte.MIN_VALUE, 0 }, new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE }));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<byte[]> borderValue4JsonDeserialized = jsonSerialization.deserializeList(byte[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<byte[]> borderValue5 = new java.util.ArrayList<byte[]>(java.util.Arrays.asList((byte[]) null, new byte[0], new byte[] { Byte.MIN_VALUE }, new byte[] { Byte.MIN_VALUE, 0 }, new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE }));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<byte[]> borderValue5JsonDeserialized = jsonSerialization.deserializeList(byte[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Binary/OneListOfOneBinariesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Binary/OneListOfOneBinariesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Binary;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfOneBinariesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<byte[]> defaultValue = new java.util.ArrayList<byte[]>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<byte[]> defaultValueJsonDeserialized = jsonSerialization.deserializeList(byte[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<byte[]> borderValue1 = new java.util.ArrayList<byte[]>(java.util.Arrays.asList(new byte[0]));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<byte[]> borderValue1JsonDeserialized = jsonSerialization.deserializeList(byte[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<byte[]> borderValue2 = new java.util.ArrayList<byte[]>(java.util.Arrays.asList(new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE }));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<byte[]> borderValue2JsonDeserialized = jsonSerialization.deserializeList(byte[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<byte[]> borderValue3 = new java.util.ArrayList<byte[]>(java.util.Arrays.asList(new byte[0], new byte[] { Byte.MIN_VALUE }, new byte[] { Byte.MIN_VALUE, 0 }, new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE }));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<byte[]> borderValue3JsonDeserialized = jsonSerialization.deserializeList(byte[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Binary/OneSetOfNullableBinariesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Binary/OneSetOfNullableBinariesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Binary;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfNullableBinariesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<byte[]> defaultValue = new java.util.HashSet<byte[]>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<byte[]> defaultValueJsonDeserialized = new java.util.HashSet<byte[]>(jsonSerialization.deserializeList(byte[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<byte[]> borderValue1 = new java.util.HashSet<byte[]>(java.util.Arrays.asList((byte[]) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<byte[]> borderValue1JsonDeserialized = new java.util.HashSet<byte[]>(jsonSerialization.deserializeList(byte[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<byte[]> borderValue2 = new java.util.HashSet<byte[]>(java.util.Arrays.asList(new byte[0]));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<byte[]> borderValue2JsonDeserialized = new java.util.HashSet<byte[]>(jsonSerialization.deserializeList(byte[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<byte[]> borderValue3 = new java.util.HashSet<byte[]>(java.util.Arrays.asList(new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE }));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<byte[]> borderValue3JsonDeserialized = new java.util.HashSet<byte[]>(jsonSerialization.deserializeList(byte[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<byte[]> borderValue4 = new java.util.HashSet<byte[]>(java.util.Arrays.asList(new byte[0], new byte[] { Byte.MIN_VALUE }, new byte[] { Byte.MIN_VALUE, 0 }, new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE }));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<byte[]> borderValue4JsonDeserialized = new java.util.HashSet<byte[]>(jsonSerialization.deserializeList(byte[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<byte[]> borderValue5 = new java.util.HashSet<byte[]>(java.util.Arrays.asList((byte[]) null, new byte[0], new byte[] { Byte.MIN_VALUE }, new byte[] { Byte.MIN_VALUE, 0 }, new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE }));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<byte[]> borderValue5JsonDeserialized = new java.util.HashSet<byte[]>(jsonSerialization.deserializeList(byte[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Binary/OneSetOfOneBinariesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Binary/OneSetOfOneBinariesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Binary;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfOneBinariesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<byte[]> defaultValue = new java.util.HashSet<byte[]>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<byte[]> defaultValueJsonDeserialized = new java.util.HashSet<byte[]>(jsonSerialization.deserializeList(byte[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<byte[]> borderValue1 = new java.util.HashSet<byte[]>(java.util.Arrays.asList(new byte[0]));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<byte[]> borderValue1JsonDeserialized = new java.util.HashSet<byte[]>(jsonSerialization.deserializeList(byte[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<byte[]> borderValue2 = new java.util.HashSet<byte[]>(java.util.Arrays.asList(new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE }));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<byte[]> borderValue2JsonDeserialized = new java.util.HashSet<byte[]>(jsonSerialization.deserializeList(byte[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<byte[]> borderValue3 = new java.util.HashSet<byte[]>(java.util.Arrays.asList(new byte[0], new byte[] { Byte.MIN_VALUE }, new byte[] { Byte.MIN_VALUE, 0 }, new byte[] { Byte.MIN_VALUE, 0, Byte.MAX_VALUE }));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<byte[]> borderValue3JsonDeserialized = new java.util.HashSet<byte[]>(jsonSerialization.deserializeList(byte[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BinaryAsserts.assertOneSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Boolean/NullableArrayOfNullableBooleansDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Boolean/NullableArrayOfNullableBooleansDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Boolean;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfNullableBooleansDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final Boolean[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final Boolean[] defaultValueJsonDeserialized = jsonSerialization.deserialize(Boolean[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final Boolean[] borderValue1 = new Boolean[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final Boolean[] borderValue1JsonDeserialized = jsonSerialization.deserialize(Boolean[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final Boolean[] borderValue2 = new Boolean[] { false };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final Boolean[] borderValue2JsonDeserialized = jsonSerialization.deserialize(Boolean[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final Boolean[] borderValue3 = new Boolean[] { true };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final Boolean[] borderValue3JsonDeserialized = jsonSerialization.deserialize(Boolean[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final Boolean[] borderValue4 = new Boolean[] { false, true };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final Boolean[] borderValue4JsonDeserialized = jsonSerialization.deserialize(Boolean[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final Boolean[] borderValue5 = new Boolean[] { null, false, true };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final Boolean[] borderValue5JsonDeserialized = jsonSerialization.deserialize(Boolean[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Boolean/NullableArrayOfOneBooleansDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Boolean/NullableArrayOfOneBooleansDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Boolean;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfOneBooleansDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final boolean[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final boolean[] defaultValueJsonDeserialized = jsonSerialization.deserialize(boolean[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final boolean[] borderValue1 = new boolean[] { false };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final boolean[] borderValue1JsonDeserialized = jsonSerialization.deserialize(boolean[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final boolean[] borderValue2 = new boolean[] { true };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final boolean[] borderValue2JsonDeserialized = jsonSerialization.deserialize(boolean[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final boolean[] borderValue3 = new boolean[] { false, true };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final boolean[] borderValue3JsonDeserialized = jsonSerialization.deserialize(boolean[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Boolean/NullableBooleanDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Boolean/NullableBooleanDefaultValueTurtle.java
@@ -1,0 +1,46 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Boolean;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableBooleanDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final Boolean defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final Boolean defaultValueJsonDeserialized = jsonSerialization.deserialize(Boolean.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final Boolean borderValue1 = false;
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final Boolean borderValue1JsonDeserialized = jsonSerialization.deserialize(Boolean.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final Boolean borderValue2 = true;
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final Boolean borderValue2JsonDeserialized = jsonSerialization.deserialize(Boolean.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Boolean/NullableListOfNullableBooleansDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Boolean/NullableListOfNullableBooleansDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Boolean;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfNullableBooleansDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<Boolean> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<Boolean> defaultValueJsonDeserialized = jsonSerialization.deserializeList(Boolean.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<Boolean> borderValue1 = new java.util.ArrayList<Boolean>(java.util.Arrays.asList((Boolean) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<Boolean> borderValue1JsonDeserialized = jsonSerialization.deserializeList(Boolean.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<Boolean> borderValue2 = new java.util.ArrayList<Boolean>(java.util.Arrays.asList(false));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<Boolean> borderValue2JsonDeserialized = jsonSerialization.deserializeList(Boolean.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<Boolean> borderValue3 = new java.util.ArrayList<Boolean>(java.util.Arrays.asList(true));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<Boolean> borderValue3JsonDeserialized = jsonSerialization.deserializeList(Boolean.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<Boolean> borderValue4 = new java.util.ArrayList<Boolean>(java.util.Arrays.asList(false, true));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<Boolean> borderValue4JsonDeserialized = jsonSerialization.deserializeList(Boolean.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<Boolean> borderValue5 = new java.util.ArrayList<Boolean>(java.util.Arrays.asList((Boolean) null, false, true));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<Boolean> borderValue5JsonDeserialized = jsonSerialization.deserializeList(Boolean.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Boolean/NullableListOfOneBooleansDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Boolean/NullableListOfOneBooleansDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Boolean;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfOneBooleansDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<Boolean> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<Boolean> defaultValueJsonDeserialized = jsonSerialization.deserializeList(Boolean.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<Boolean> borderValue1 = new java.util.ArrayList<Boolean>(java.util.Arrays.asList(false));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<Boolean> borderValue1JsonDeserialized = jsonSerialization.deserializeList(Boolean.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<Boolean> borderValue2 = new java.util.ArrayList<Boolean>(java.util.Arrays.asList(true));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<Boolean> borderValue2JsonDeserialized = jsonSerialization.deserializeList(Boolean.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<Boolean> borderValue3 = new java.util.ArrayList<Boolean>(java.util.Arrays.asList(false, true));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<Boolean> borderValue3JsonDeserialized = jsonSerialization.deserializeList(Boolean.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Boolean/NullableSetOfNullableBooleansDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Boolean/NullableSetOfNullableBooleansDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Boolean;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfNullableBooleansDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<Boolean> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<Boolean> defaultValueJsonDeserialized = new java.util.HashSet<Boolean>(jsonSerialization.deserializeList(Boolean.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<Boolean> borderValue1 = new java.util.HashSet<Boolean>(java.util.Arrays.asList((Boolean) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<Boolean> borderValue1JsonDeserialized = new java.util.HashSet<Boolean>(jsonSerialization.deserializeList(Boolean.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<Boolean> borderValue2 = new java.util.HashSet<Boolean>(java.util.Arrays.asList(false));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<Boolean> borderValue2JsonDeserialized = new java.util.HashSet<Boolean>(jsonSerialization.deserializeList(Boolean.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<Boolean> borderValue3 = new java.util.HashSet<Boolean>(java.util.Arrays.asList(true));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<Boolean> borderValue3JsonDeserialized = new java.util.HashSet<Boolean>(jsonSerialization.deserializeList(Boolean.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<Boolean> borderValue4 = new java.util.HashSet<Boolean>(java.util.Arrays.asList(false, true));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<Boolean> borderValue4JsonDeserialized = new java.util.HashSet<Boolean>(jsonSerialization.deserializeList(Boolean.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<Boolean> borderValue5 = new java.util.HashSet<Boolean>(java.util.Arrays.asList((Boolean) null, false, true));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<Boolean> borderValue5JsonDeserialized = new java.util.HashSet<Boolean>(jsonSerialization.deserializeList(Boolean.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Boolean/NullableSetOfOneBooleansDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Boolean/NullableSetOfOneBooleansDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Boolean;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfOneBooleansDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<Boolean> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<Boolean> defaultValueJsonDeserialized = new java.util.HashSet<Boolean>(jsonSerialization.deserializeList(Boolean.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<Boolean> borderValue1 = new java.util.HashSet<Boolean>(java.util.Arrays.asList(false));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<Boolean> borderValue1JsonDeserialized = new java.util.HashSet<Boolean>(jsonSerialization.deserializeList(Boolean.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<Boolean> borderValue2 = new java.util.HashSet<Boolean>(java.util.Arrays.asList(true));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<Boolean> borderValue2JsonDeserialized = new java.util.HashSet<Boolean>(jsonSerialization.deserializeList(Boolean.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<Boolean> borderValue3 = new java.util.HashSet<Boolean>(java.util.Arrays.asList(false, true));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<Boolean> borderValue3JsonDeserialized = new java.util.HashSet<Boolean>(jsonSerialization.deserializeList(Boolean.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertNullableSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Boolean/OneArrayOfNullableBooleansDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Boolean/OneArrayOfNullableBooleansDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Boolean;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfNullableBooleansDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final Boolean[] defaultValue = new Boolean[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final Boolean[] defaultValueJsonDeserialized = jsonSerialization.deserialize(Boolean[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final Boolean[] borderValue1 = new Boolean[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final Boolean[] borderValue1JsonDeserialized = jsonSerialization.deserialize(Boolean[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final Boolean[] borderValue2 = new Boolean[] { false };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final Boolean[] borderValue2JsonDeserialized = jsonSerialization.deserialize(Boolean[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final Boolean[] borderValue3 = new Boolean[] { true };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final Boolean[] borderValue3JsonDeserialized = jsonSerialization.deserialize(Boolean[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final Boolean[] borderValue4 = new Boolean[] { false, true };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final Boolean[] borderValue4JsonDeserialized = jsonSerialization.deserialize(Boolean[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final Boolean[] borderValue5 = new Boolean[] { null, false, true };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final Boolean[] borderValue5JsonDeserialized = jsonSerialization.deserialize(Boolean[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Boolean/OneArrayOfOneBooleansDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Boolean/OneArrayOfOneBooleansDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Boolean;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfOneBooleansDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final boolean[] defaultValue = new boolean[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final boolean[] defaultValueJsonDeserialized = jsonSerialization.deserialize(boolean[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final boolean[] borderValue1 = new boolean[] { false };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final boolean[] borderValue1JsonDeserialized = jsonSerialization.deserialize(boolean[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final boolean[] borderValue2 = new boolean[] { true };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final boolean[] borderValue2JsonDeserialized = jsonSerialization.deserialize(boolean[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final boolean[] borderValue3 = new boolean[] { false, true };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final boolean[] borderValue3JsonDeserialized = jsonSerialization.deserialize(boolean[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Boolean/OneBooleanDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Boolean/OneBooleanDefaultValueTurtle.java
@@ -1,0 +1,37 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Boolean;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneBooleanDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final boolean defaultValue = false;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final boolean defaultValueJsonDeserialized = jsonSerialization.deserialize(boolean.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final boolean borderValue1 = true;
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final boolean borderValue1JsonDeserialized = jsonSerialization.deserialize(boolean.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Boolean/OneListOfNullableBooleansDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Boolean/OneListOfNullableBooleansDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Boolean;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfNullableBooleansDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<Boolean> defaultValue = new java.util.ArrayList<Boolean>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<Boolean> defaultValueJsonDeserialized = jsonSerialization.deserializeList(Boolean.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<Boolean> borderValue1 = new java.util.ArrayList<Boolean>(java.util.Arrays.asList((Boolean) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<Boolean> borderValue1JsonDeserialized = jsonSerialization.deserializeList(Boolean.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<Boolean> borderValue2 = new java.util.ArrayList<Boolean>(java.util.Arrays.asList(false));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<Boolean> borderValue2JsonDeserialized = jsonSerialization.deserializeList(Boolean.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<Boolean> borderValue3 = new java.util.ArrayList<Boolean>(java.util.Arrays.asList(true));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<Boolean> borderValue3JsonDeserialized = jsonSerialization.deserializeList(Boolean.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<Boolean> borderValue4 = new java.util.ArrayList<Boolean>(java.util.Arrays.asList(false, true));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<Boolean> borderValue4JsonDeserialized = jsonSerialization.deserializeList(Boolean.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<Boolean> borderValue5 = new java.util.ArrayList<Boolean>(java.util.Arrays.asList((Boolean) null, false, true));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<Boolean> borderValue5JsonDeserialized = jsonSerialization.deserializeList(Boolean.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Boolean/OneListOfOneBooleansDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Boolean/OneListOfOneBooleansDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Boolean;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfOneBooleansDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<Boolean> defaultValue = new java.util.ArrayList<Boolean>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<Boolean> defaultValueJsonDeserialized = jsonSerialization.deserializeList(Boolean.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<Boolean> borderValue1 = new java.util.ArrayList<Boolean>(java.util.Arrays.asList(false));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<Boolean> borderValue1JsonDeserialized = jsonSerialization.deserializeList(Boolean.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<Boolean> borderValue2 = new java.util.ArrayList<Boolean>(java.util.Arrays.asList(true));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<Boolean> borderValue2JsonDeserialized = jsonSerialization.deserializeList(Boolean.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<Boolean> borderValue3 = new java.util.ArrayList<Boolean>(java.util.Arrays.asList(false, true));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<Boolean> borderValue3JsonDeserialized = jsonSerialization.deserializeList(Boolean.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Boolean/OneSetOfNullableBooleansDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Boolean/OneSetOfNullableBooleansDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Boolean;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfNullableBooleansDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<Boolean> defaultValue = new java.util.HashSet<Boolean>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<Boolean> defaultValueJsonDeserialized = new java.util.HashSet<Boolean>(jsonSerialization.deserializeList(Boolean.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<Boolean> borderValue1 = new java.util.HashSet<Boolean>(java.util.Arrays.asList((Boolean) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<Boolean> borderValue1JsonDeserialized = new java.util.HashSet<Boolean>(jsonSerialization.deserializeList(Boolean.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<Boolean> borderValue2 = new java.util.HashSet<Boolean>(java.util.Arrays.asList(false));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<Boolean> borderValue2JsonDeserialized = new java.util.HashSet<Boolean>(jsonSerialization.deserializeList(Boolean.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<Boolean> borderValue3 = new java.util.HashSet<Boolean>(java.util.Arrays.asList(true));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<Boolean> borderValue3JsonDeserialized = new java.util.HashSet<Boolean>(jsonSerialization.deserializeList(Boolean.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<Boolean> borderValue4 = new java.util.HashSet<Boolean>(java.util.Arrays.asList(false, true));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<Boolean> borderValue4JsonDeserialized = new java.util.HashSet<Boolean>(jsonSerialization.deserializeList(Boolean.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<Boolean> borderValue5 = new java.util.HashSet<Boolean>(java.util.Arrays.asList((Boolean) null, false, true));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<Boolean> borderValue5JsonDeserialized = new java.util.HashSet<Boolean>(jsonSerialization.deserializeList(Boolean.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Boolean/OneSetOfOneBooleansDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Boolean/OneSetOfOneBooleansDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Boolean;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfOneBooleansDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<Boolean> defaultValue = new java.util.HashSet<Boolean>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<Boolean> defaultValueJsonDeserialized = new java.util.HashSet<Boolean>(jsonSerialization.deserializeList(Boolean.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<Boolean> borderValue1 = new java.util.HashSet<Boolean>(java.util.Arrays.asList(false));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<Boolean> borderValue1JsonDeserialized = new java.util.HashSet<Boolean>(jsonSerialization.deserializeList(Boolean.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<Boolean> borderValue2 = new java.util.HashSet<Boolean>(java.util.Arrays.asList(true));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<Boolean> borderValue2JsonDeserialized = new java.util.HashSet<Boolean>(jsonSerialization.deserializeList(Boolean.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<Boolean> borderValue3 = new java.util.HashSet<Boolean>(java.util.Arrays.asList(false, true));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<Boolean> borderValue3JsonDeserialized = new java.util.HashSet<Boolean>(jsonSerialization.deserializeList(Boolean.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.BooleanAsserts.assertOneSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Date/NullableArrayOfNullableDatesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Date/NullableArrayOfNullableDatesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Date;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfNullableDatesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final org.joda.time.LocalDate[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final org.joda.time.LocalDate[] defaultValueJsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final org.joda.time.LocalDate[] borderValue1 = new org.joda.time.LocalDate[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final org.joda.time.LocalDate[] borderValue1JsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final org.joda.time.LocalDate[] borderValue2 = new org.joda.time.LocalDate[] { org.joda.time.LocalDate.now() };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final org.joda.time.LocalDate[] borderValue2JsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final org.joda.time.LocalDate[] borderValue3 = new org.joda.time.LocalDate[] { new org.joda.time.LocalDate(9999, 12, 31) };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final org.joda.time.LocalDate[] borderValue3JsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final org.joda.time.LocalDate[] borderValue4 = new org.joda.time.LocalDate[] { org.joda.time.LocalDate.now(), new org.joda.time.LocalDate(1, 2, 3), new org.joda.time.LocalDate(1, 1, 1), new org.joda.time.LocalDate(0), new org.joda.time.LocalDate(Integer.MAX_VALUE * 1001L), new org.joda.time.LocalDate(9999, 12, 31) };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final org.joda.time.LocalDate[] borderValue4JsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final org.joda.time.LocalDate[] borderValue5 = new org.joda.time.LocalDate[] { null, org.joda.time.LocalDate.now(), new org.joda.time.LocalDate(1, 2, 3), new org.joda.time.LocalDate(1, 1, 1), new org.joda.time.LocalDate(0), new org.joda.time.LocalDate(Integer.MAX_VALUE * 1001L), new org.joda.time.LocalDate(9999, 12, 31) };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final org.joda.time.LocalDate[] borderValue5JsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Date/NullableArrayOfOneDatesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Date/NullableArrayOfOneDatesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Date;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfOneDatesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final org.joda.time.LocalDate[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final org.joda.time.LocalDate[] defaultValueJsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final org.joda.time.LocalDate[] borderValue1 = new org.joda.time.LocalDate[] { org.joda.time.LocalDate.now() };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final org.joda.time.LocalDate[] borderValue1JsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final org.joda.time.LocalDate[] borderValue2 = new org.joda.time.LocalDate[] { new org.joda.time.LocalDate(9999, 12, 31) };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final org.joda.time.LocalDate[] borderValue2JsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final org.joda.time.LocalDate[] borderValue3 = new org.joda.time.LocalDate[] { org.joda.time.LocalDate.now(), new org.joda.time.LocalDate(1, 2, 3), new org.joda.time.LocalDate(1, 1, 1), new org.joda.time.LocalDate(0), new org.joda.time.LocalDate(Integer.MAX_VALUE * 1001L), new org.joda.time.LocalDate(9999, 12, 31) };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final org.joda.time.LocalDate[] borderValue3JsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Date/NullableDateDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Date/NullableDateDefaultValueTurtle.java
@@ -1,0 +1,82 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Date;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableDateDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final org.joda.time.LocalDate defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final org.joda.time.LocalDate defaultValueJsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final org.joda.time.LocalDate borderValue1 = org.joda.time.LocalDate.now();
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final org.joda.time.LocalDate borderValue1JsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final org.joda.time.LocalDate borderValue2 = new org.joda.time.LocalDate(1, 2, 3);
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final org.joda.time.LocalDate borderValue2JsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final org.joda.time.LocalDate borderValue3 = new org.joda.time.LocalDate(1, 1, 1);
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final org.joda.time.LocalDate borderValue3JsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final org.joda.time.LocalDate borderValue4 = new org.joda.time.LocalDate(0);
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final org.joda.time.LocalDate borderValue4JsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final org.joda.time.LocalDate borderValue5 = new org.joda.time.LocalDate(Integer.MAX_VALUE * 1001L);
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final org.joda.time.LocalDate borderValue5JsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue6Equality() throws IOException {
+        final org.joda.time.LocalDate borderValue6 = new org.joda.time.LocalDate(9999, 12, 31);
+        final Bytes borderValue6JsonSerialized = jsonSerialization.serialize(borderValue6);
+        final org.joda.time.LocalDate borderValue6JsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate.class, borderValue6JsonSerialized.content, borderValue6JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableEquals(borderValue6, borderValue6JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Date/NullableListOfNullableDatesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Date/NullableListOfNullableDatesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Date;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfNullableDatesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<org.joda.time.LocalDate> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<org.joda.time.LocalDate> defaultValueJsonDeserialized = jsonSerialization.deserializeList(org.joda.time.LocalDate.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<org.joda.time.LocalDate> borderValue1 = new java.util.ArrayList<org.joda.time.LocalDate>(java.util.Arrays.asList((org.joda.time.LocalDate) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<org.joda.time.LocalDate> borderValue1JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<org.joda.time.LocalDate> borderValue2 = new java.util.ArrayList<org.joda.time.LocalDate>(java.util.Arrays.asList(org.joda.time.LocalDate.now()));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<org.joda.time.LocalDate> borderValue2JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<org.joda.time.LocalDate> borderValue3 = new java.util.ArrayList<org.joda.time.LocalDate>(java.util.Arrays.asList(new org.joda.time.LocalDate(9999, 12, 31)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<org.joda.time.LocalDate> borderValue3JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<org.joda.time.LocalDate> borderValue4 = new java.util.ArrayList<org.joda.time.LocalDate>(java.util.Arrays.asList(org.joda.time.LocalDate.now(), new org.joda.time.LocalDate(1, 2, 3), new org.joda.time.LocalDate(1, 1, 1), new org.joda.time.LocalDate(0), new org.joda.time.LocalDate(Integer.MAX_VALUE * 1001L), new org.joda.time.LocalDate(9999, 12, 31)));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<org.joda.time.LocalDate> borderValue4JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<org.joda.time.LocalDate> borderValue5 = new java.util.ArrayList<org.joda.time.LocalDate>(java.util.Arrays.asList((org.joda.time.LocalDate) null, org.joda.time.LocalDate.now(), new org.joda.time.LocalDate(1, 2, 3), new org.joda.time.LocalDate(1, 1, 1), new org.joda.time.LocalDate(0), new org.joda.time.LocalDate(Integer.MAX_VALUE * 1001L), new org.joda.time.LocalDate(9999, 12, 31)));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<org.joda.time.LocalDate> borderValue5JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Date/NullableListOfOneDatesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Date/NullableListOfOneDatesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Date;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfOneDatesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<org.joda.time.LocalDate> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<org.joda.time.LocalDate> defaultValueJsonDeserialized = jsonSerialization.deserializeList(org.joda.time.LocalDate.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<org.joda.time.LocalDate> borderValue1 = new java.util.ArrayList<org.joda.time.LocalDate>(java.util.Arrays.asList(org.joda.time.LocalDate.now()));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<org.joda.time.LocalDate> borderValue1JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<org.joda.time.LocalDate> borderValue2 = new java.util.ArrayList<org.joda.time.LocalDate>(java.util.Arrays.asList(new org.joda.time.LocalDate(9999, 12, 31)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<org.joda.time.LocalDate> borderValue2JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<org.joda.time.LocalDate> borderValue3 = new java.util.ArrayList<org.joda.time.LocalDate>(java.util.Arrays.asList(org.joda.time.LocalDate.now(), new org.joda.time.LocalDate(1, 2, 3), new org.joda.time.LocalDate(1, 1, 1), new org.joda.time.LocalDate(0), new org.joda.time.LocalDate(Integer.MAX_VALUE * 1001L), new org.joda.time.LocalDate(9999, 12, 31)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<org.joda.time.LocalDate> borderValue3JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Date/NullableSetOfNullableDatesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Date/NullableSetOfNullableDatesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Date;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfNullableDatesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<org.joda.time.LocalDate> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<org.joda.time.LocalDate> defaultValueJsonDeserialized = new java.util.HashSet<org.joda.time.LocalDate>(jsonSerialization.deserializeList(org.joda.time.LocalDate.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<org.joda.time.LocalDate> borderValue1 = new java.util.HashSet<org.joda.time.LocalDate>(java.util.Arrays.asList((org.joda.time.LocalDate) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<org.joda.time.LocalDate> borderValue1JsonDeserialized = new java.util.HashSet<org.joda.time.LocalDate>(jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<org.joda.time.LocalDate> borderValue2 = new java.util.HashSet<org.joda.time.LocalDate>(java.util.Arrays.asList(org.joda.time.LocalDate.now()));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<org.joda.time.LocalDate> borderValue2JsonDeserialized = new java.util.HashSet<org.joda.time.LocalDate>(jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<org.joda.time.LocalDate> borderValue3 = new java.util.HashSet<org.joda.time.LocalDate>(java.util.Arrays.asList(new org.joda.time.LocalDate(9999, 12, 31)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<org.joda.time.LocalDate> borderValue3JsonDeserialized = new java.util.HashSet<org.joda.time.LocalDate>(jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<org.joda.time.LocalDate> borderValue4 = new java.util.HashSet<org.joda.time.LocalDate>(java.util.Arrays.asList(org.joda.time.LocalDate.now(), new org.joda.time.LocalDate(1, 2, 3), new org.joda.time.LocalDate(1, 1, 1), new org.joda.time.LocalDate(0), new org.joda.time.LocalDate(Integer.MAX_VALUE * 1001L), new org.joda.time.LocalDate(9999, 12, 31)));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<org.joda.time.LocalDate> borderValue4JsonDeserialized = new java.util.HashSet<org.joda.time.LocalDate>(jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<org.joda.time.LocalDate> borderValue5 = new java.util.HashSet<org.joda.time.LocalDate>(java.util.Arrays.asList((org.joda.time.LocalDate) null, org.joda.time.LocalDate.now(), new org.joda.time.LocalDate(1, 2, 3), new org.joda.time.LocalDate(1, 1, 1), new org.joda.time.LocalDate(0), new org.joda.time.LocalDate(Integer.MAX_VALUE * 1001L), new org.joda.time.LocalDate(9999, 12, 31)));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<org.joda.time.LocalDate> borderValue5JsonDeserialized = new java.util.HashSet<org.joda.time.LocalDate>(jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Date/NullableSetOfOneDatesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Date/NullableSetOfOneDatesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Date;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfOneDatesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<org.joda.time.LocalDate> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<org.joda.time.LocalDate> defaultValueJsonDeserialized = new java.util.HashSet<org.joda.time.LocalDate>(jsonSerialization.deserializeList(org.joda.time.LocalDate.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<org.joda.time.LocalDate> borderValue1 = new java.util.HashSet<org.joda.time.LocalDate>(java.util.Arrays.asList(org.joda.time.LocalDate.now()));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<org.joda.time.LocalDate> borderValue1JsonDeserialized = new java.util.HashSet<org.joda.time.LocalDate>(jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<org.joda.time.LocalDate> borderValue2 = new java.util.HashSet<org.joda.time.LocalDate>(java.util.Arrays.asList(new org.joda.time.LocalDate(9999, 12, 31)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<org.joda.time.LocalDate> borderValue2JsonDeserialized = new java.util.HashSet<org.joda.time.LocalDate>(jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<org.joda.time.LocalDate> borderValue3 = new java.util.HashSet<org.joda.time.LocalDate>(java.util.Arrays.asList(org.joda.time.LocalDate.now(), new org.joda.time.LocalDate(1, 2, 3), new org.joda.time.LocalDate(1, 1, 1), new org.joda.time.LocalDate(0), new org.joda.time.LocalDate(Integer.MAX_VALUE * 1001L), new org.joda.time.LocalDate(9999, 12, 31)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<org.joda.time.LocalDate> borderValue3JsonDeserialized = new java.util.HashSet<org.joda.time.LocalDate>(jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertNullableSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Date/OneArrayOfNullableDatesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Date/OneArrayOfNullableDatesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Date;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfNullableDatesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final org.joda.time.LocalDate[] defaultValue = new org.joda.time.LocalDate[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final org.joda.time.LocalDate[] defaultValueJsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final org.joda.time.LocalDate[] borderValue1 = new org.joda.time.LocalDate[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final org.joda.time.LocalDate[] borderValue1JsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final org.joda.time.LocalDate[] borderValue2 = new org.joda.time.LocalDate[] { org.joda.time.LocalDate.now() };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final org.joda.time.LocalDate[] borderValue2JsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final org.joda.time.LocalDate[] borderValue3 = new org.joda.time.LocalDate[] { new org.joda.time.LocalDate(9999, 12, 31) };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final org.joda.time.LocalDate[] borderValue3JsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final org.joda.time.LocalDate[] borderValue4 = new org.joda.time.LocalDate[] { org.joda.time.LocalDate.now(), new org.joda.time.LocalDate(1, 2, 3), new org.joda.time.LocalDate(1, 1, 1), new org.joda.time.LocalDate(0), new org.joda.time.LocalDate(Integer.MAX_VALUE * 1001L), new org.joda.time.LocalDate(9999, 12, 31) };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final org.joda.time.LocalDate[] borderValue4JsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final org.joda.time.LocalDate[] borderValue5 = new org.joda.time.LocalDate[] { null, org.joda.time.LocalDate.now(), new org.joda.time.LocalDate(1, 2, 3), new org.joda.time.LocalDate(1, 1, 1), new org.joda.time.LocalDate(0), new org.joda.time.LocalDate(Integer.MAX_VALUE * 1001L), new org.joda.time.LocalDate(9999, 12, 31) };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final org.joda.time.LocalDate[] borderValue5JsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Date/OneArrayOfOneDatesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Date/OneArrayOfOneDatesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Date;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfOneDatesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final org.joda.time.LocalDate[] defaultValue = new org.joda.time.LocalDate[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final org.joda.time.LocalDate[] defaultValueJsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final org.joda.time.LocalDate[] borderValue1 = new org.joda.time.LocalDate[] { org.joda.time.LocalDate.now() };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final org.joda.time.LocalDate[] borderValue1JsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final org.joda.time.LocalDate[] borderValue2 = new org.joda.time.LocalDate[] { new org.joda.time.LocalDate(9999, 12, 31) };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final org.joda.time.LocalDate[] borderValue2JsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final org.joda.time.LocalDate[] borderValue3 = new org.joda.time.LocalDate[] { org.joda.time.LocalDate.now(), new org.joda.time.LocalDate(1, 2, 3), new org.joda.time.LocalDate(1, 1, 1), new org.joda.time.LocalDate(0), new org.joda.time.LocalDate(Integer.MAX_VALUE * 1001L), new org.joda.time.LocalDate(9999, 12, 31) };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final org.joda.time.LocalDate[] borderValue3JsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Date/OneDateDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Date/OneDateDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Date;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneDateDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final org.joda.time.LocalDate defaultValue = org.joda.time.LocalDate.now();
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final org.joda.time.LocalDate defaultValueJsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final org.joda.time.LocalDate borderValue1 = new org.joda.time.LocalDate(1, 2, 3);
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final org.joda.time.LocalDate borderValue1JsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final org.joda.time.LocalDate borderValue2 = new org.joda.time.LocalDate(1, 1, 1);
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final org.joda.time.LocalDate borderValue2JsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final org.joda.time.LocalDate borderValue3 = new org.joda.time.LocalDate(0);
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final org.joda.time.LocalDate borderValue3JsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final org.joda.time.LocalDate borderValue4 = new org.joda.time.LocalDate(Integer.MAX_VALUE * 1001L);
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final org.joda.time.LocalDate borderValue4JsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final org.joda.time.LocalDate borderValue5 = new org.joda.time.LocalDate(9999, 12, 31);
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final org.joda.time.LocalDate borderValue5JsonDeserialized = jsonSerialization.deserialize(org.joda.time.LocalDate.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Date/OneListOfNullableDatesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Date/OneListOfNullableDatesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Date;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfNullableDatesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<org.joda.time.LocalDate> defaultValue = new java.util.ArrayList<org.joda.time.LocalDate>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<org.joda.time.LocalDate> defaultValueJsonDeserialized = jsonSerialization.deserializeList(org.joda.time.LocalDate.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<org.joda.time.LocalDate> borderValue1 = new java.util.ArrayList<org.joda.time.LocalDate>(java.util.Arrays.asList((org.joda.time.LocalDate) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<org.joda.time.LocalDate> borderValue1JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<org.joda.time.LocalDate> borderValue2 = new java.util.ArrayList<org.joda.time.LocalDate>(java.util.Arrays.asList(org.joda.time.LocalDate.now()));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<org.joda.time.LocalDate> borderValue2JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<org.joda.time.LocalDate> borderValue3 = new java.util.ArrayList<org.joda.time.LocalDate>(java.util.Arrays.asList(new org.joda.time.LocalDate(9999, 12, 31)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<org.joda.time.LocalDate> borderValue3JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<org.joda.time.LocalDate> borderValue4 = new java.util.ArrayList<org.joda.time.LocalDate>(java.util.Arrays.asList(org.joda.time.LocalDate.now(), new org.joda.time.LocalDate(1, 2, 3), new org.joda.time.LocalDate(1, 1, 1), new org.joda.time.LocalDate(0), new org.joda.time.LocalDate(Integer.MAX_VALUE * 1001L), new org.joda.time.LocalDate(9999, 12, 31)));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<org.joda.time.LocalDate> borderValue4JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<org.joda.time.LocalDate> borderValue5 = new java.util.ArrayList<org.joda.time.LocalDate>(java.util.Arrays.asList((org.joda.time.LocalDate) null, org.joda.time.LocalDate.now(), new org.joda.time.LocalDate(1, 2, 3), new org.joda.time.LocalDate(1, 1, 1), new org.joda.time.LocalDate(0), new org.joda.time.LocalDate(Integer.MAX_VALUE * 1001L), new org.joda.time.LocalDate(9999, 12, 31)));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<org.joda.time.LocalDate> borderValue5JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Date/OneListOfOneDatesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Date/OneListOfOneDatesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Date;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfOneDatesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<org.joda.time.LocalDate> defaultValue = new java.util.ArrayList<org.joda.time.LocalDate>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<org.joda.time.LocalDate> defaultValueJsonDeserialized = jsonSerialization.deserializeList(org.joda.time.LocalDate.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<org.joda.time.LocalDate> borderValue1 = new java.util.ArrayList<org.joda.time.LocalDate>(java.util.Arrays.asList(org.joda.time.LocalDate.now()));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<org.joda.time.LocalDate> borderValue1JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<org.joda.time.LocalDate> borderValue2 = new java.util.ArrayList<org.joda.time.LocalDate>(java.util.Arrays.asList(new org.joda.time.LocalDate(9999, 12, 31)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<org.joda.time.LocalDate> borderValue2JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<org.joda.time.LocalDate> borderValue3 = new java.util.ArrayList<org.joda.time.LocalDate>(java.util.Arrays.asList(org.joda.time.LocalDate.now(), new org.joda.time.LocalDate(1, 2, 3), new org.joda.time.LocalDate(1, 1, 1), new org.joda.time.LocalDate(0), new org.joda.time.LocalDate(Integer.MAX_VALUE * 1001L), new org.joda.time.LocalDate(9999, 12, 31)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<org.joda.time.LocalDate> borderValue3JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Date/OneSetOfNullableDatesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Date/OneSetOfNullableDatesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Date;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfNullableDatesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<org.joda.time.LocalDate> defaultValue = new java.util.HashSet<org.joda.time.LocalDate>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<org.joda.time.LocalDate> defaultValueJsonDeserialized = new java.util.HashSet<org.joda.time.LocalDate>(jsonSerialization.deserializeList(org.joda.time.LocalDate.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<org.joda.time.LocalDate> borderValue1 = new java.util.HashSet<org.joda.time.LocalDate>(java.util.Arrays.asList((org.joda.time.LocalDate) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<org.joda.time.LocalDate> borderValue1JsonDeserialized = new java.util.HashSet<org.joda.time.LocalDate>(jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<org.joda.time.LocalDate> borderValue2 = new java.util.HashSet<org.joda.time.LocalDate>(java.util.Arrays.asList(org.joda.time.LocalDate.now()));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<org.joda.time.LocalDate> borderValue2JsonDeserialized = new java.util.HashSet<org.joda.time.LocalDate>(jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<org.joda.time.LocalDate> borderValue3 = new java.util.HashSet<org.joda.time.LocalDate>(java.util.Arrays.asList(new org.joda.time.LocalDate(9999, 12, 31)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<org.joda.time.LocalDate> borderValue3JsonDeserialized = new java.util.HashSet<org.joda.time.LocalDate>(jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<org.joda.time.LocalDate> borderValue4 = new java.util.HashSet<org.joda.time.LocalDate>(java.util.Arrays.asList(org.joda.time.LocalDate.now(), new org.joda.time.LocalDate(1, 2, 3), new org.joda.time.LocalDate(1, 1, 1), new org.joda.time.LocalDate(0), new org.joda.time.LocalDate(Integer.MAX_VALUE * 1001L), new org.joda.time.LocalDate(9999, 12, 31)));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<org.joda.time.LocalDate> borderValue4JsonDeserialized = new java.util.HashSet<org.joda.time.LocalDate>(jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<org.joda.time.LocalDate> borderValue5 = new java.util.HashSet<org.joda.time.LocalDate>(java.util.Arrays.asList((org.joda.time.LocalDate) null, org.joda.time.LocalDate.now(), new org.joda.time.LocalDate(1, 2, 3), new org.joda.time.LocalDate(1, 1, 1), new org.joda.time.LocalDate(0), new org.joda.time.LocalDate(Integer.MAX_VALUE * 1001L), new org.joda.time.LocalDate(9999, 12, 31)));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<org.joda.time.LocalDate> borderValue5JsonDeserialized = new java.util.HashSet<org.joda.time.LocalDate>(jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Date/OneSetOfOneDatesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Date/OneSetOfOneDatesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Date;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfOneDatesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<org.joda.time.LocalDate> defaultValue = new java.util.HashSet<org.joda.time.LocalDate>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<org.joda.time.LocalDate> defaultValueJsonDeserialized = new java.util.HashSet<org.joda.time.LocalDate>(jsonSerialization.deserializeList(org.joda.time.LocalDate.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<org.joda.time.LocalDate> borderValue1 = new java.util.HashSet<org.joda.time.LocalDate>(java.util.Arrays.asList(org.joda.time.LocalDate.now()));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<org.joda.time.LocalDate> borderValue1JsonDeserialized = new java.util.HashSet<org.joda.time.LocalDate>(jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<org.joda.time.LocalDate> borderValue2 = new java.util.HashSet<org.joda.time.LocalDate>(java.util.Arrays.asList(new org.joda.time.LocalDate(9999, 12, 31)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<org.joda.time.LocalDate> borderValue2JsonDeserialized = new java.util.HashSet<org.joda.time.LocalDate>(jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<org.joda.time.LocalDate> borderValue3 = new java.util.HashSet<org.joda.time.LocalDate>(java.util.Arrays.asList(org.joda.time.LocalDate.now(), new org.joda.time.LocalDate(1, 2, 3), new org.joda.time.LocalDate(1, 1, 1), new org.joda.time.LocalDate(0), new org.joda.time.LocalDate(Integer.MAX_VALUE * 1001L), new org.joda.time.LocalDate(9999, 12, 31)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<org.joda.time.LocalDate> borderValue3JsonDeserialized = new java.util.HashSet<org.joda.time.LocalDate>(jsonSerialization.deserializeList(org.joda.time.LocalDate.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DateAsserts.assertOneSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Decimal/NullableArrayOfNullableDecimalsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Decimal/NullableArrayOfNullableDecimalsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Decimal;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfNullableDecimalsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.math.BigDecimal[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.math.BigDecimal[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue1 = new java.math.BigDecimal[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.math.BigDecimal[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue2 = new java.math.BigDecimal[] { java.math.BigDecimal.ZERO };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.math.BigDecimal[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue3 = new java.math.BigDecimal[] { new java.math.BigDecimal("1E28") };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.math.BigDecimal[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue4 = new java.math.BigDecimal[] { java.math.BigDecimal.ZERO, java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(28, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-28"), new java.math.BigDecimal("1E28") };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.math.BigDecimal[] borderValue4JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue5 = new java.math.BigDecimal[] { null, java.math.BigDecimal.ZERO, java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(28, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-28"), new java.math.BigDecimal("1E28") };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.math.BigDecimal[] borderValue5JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Decimal/NullableArrayOfOneDecimalsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Decimal/NullableArrayOfOneDecimalsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Decimal;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfOneDecimalsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.math.BigDecimal[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.math.BigDecimal[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue1 = new java.math.BigDecimal[] { java.math.BigDecimal.ZERO };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.math.BigDecimal[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue2 = new java.math.BigDecimal[] { new java.math.BigDecimal("1E28") };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.math.BigDecimal[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue3 = new java.math.BigDecimal[] { java.math.BigDecimal.ZERO, java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(28, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-28"), new java.math.BigDecimal("1E28") };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.math.BigDecimal[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Decimal/NullableDecimalDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Decimal/NullableDecimalDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Decimal;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableDecimalDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.math.BigDecimal defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.math.BigDecimal defaultValueJsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.math.BigDecimal borderValue1 = java.math.BigDecimal.ZERO;
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.math.BigDecimal borderValue1JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.math.BigDecimal borderValue2 = java.math.BigDecimal.ONE;
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.math.BigDecimal borderValue2JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.math.BigDecimal borderValue3 = new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(28, java.math.BigDecimal.ROUND_HALF_UP);
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.math.BigDecimal borderValue3JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.math.BigDecimal borderValue4 = new java.math.BigDecimal("-1E-28");
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.math.BigDecimal borderValue4JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.math.BigDecimal borderValue5 = new java.math.BigDecimal("1E28");
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.math.BigDecimal borderValue5JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Decimal/NullableListOfNullableDecimalsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Decimal/NullableListOfNullableDecimalsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Decimal;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfNullableDecimalsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.math.BigDecimal> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.math.BigDecimal> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue1 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList((java.math.BigDecimal) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.math.BigDecimal> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue2 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.math.BigDecimal> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue3 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(new java.math.BigDecimal("1E28")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.math.BigDecimal> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue4 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO, java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(28, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-28"), new java.math.BigDecimal("1E28")));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<java.math.BigDecimal> borderValue4JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue5 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList((java.math.BigDecimal) null, java.math.BigDecimal.ZERO, java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(28, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-28"), new java.math.BigDecimal("1E28")));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<java.math.BigDecimal> borderValue5JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Decimal/NullableListOfOneDecimalsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Decimal/NullableListOfOneDecimalsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Decimal;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfOneDecimalsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.math.BigDecimal> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.math.BigDecimal> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue1 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.math.BigDecimal> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue2 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(new java.math.BigDecimal("1E28")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.math.BigDecimal> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue3 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO, java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(28, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-28"), new java.math.BigDecimal("1E28")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.math.BigDecimal> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Decimal/NullableSetOfNullableDecimalsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Decimal/NullableSetOfNullableDecimalsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Decimal;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfNullableDecimalsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.math.BigDecimal> defaultValueJsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue1 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList((java.math.BigDecimal) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.math.BigDecimal> borderValue1JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue2 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.math.BigDecimal> borderValue2JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue3 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(new java.math.BigDecimal("1E28")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.math.BigDecimal> borderValue3JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue4 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO, java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(28, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-28"), new java.math.BigDecimal("1E28")));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<java.math.BigDecimal> borderValue4JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue5 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList((java.math.BigDecimal) null, java.math.BigDecimal.ZERO, java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(28, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-28"), new java.math.BigDecimal("1E28")));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<java.math.BigDecimal> borderValue5JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Decimal/NullableSetOfOneDecimalsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Decimal/NullableSetOfOneDecimalsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Decimal;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfOneDecimalsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.math.BigDecimal> defaultValueJsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue1 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.math.BigDecimal> borderValue1JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue2 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(new java.math.BigDecimal("1E28")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.math.BigDecimal> borderValue2JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue3 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO, java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(28, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-28"), new java.math.BigDecimal("1E28")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.math.BigDecimal> borderValue3JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertNullableSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Decimal/OneArrayOfNullableDecimalsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Decimal/OneArrayOfNullableDecimalsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Decimal;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfNullableDecimalsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.math.BigDecimal[] defaultValue = new java.math.BigDecimal[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.math.BigDecimal[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue1 = new java.math.BigDecimal[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.math.BigDecimal[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue2 = new java.math.BigDecimal[] { java.math.BigDecimal.ZERO };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.math.BigDecimal[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue3 = new java.math.BigDecimal[] { new java.math.BigDecimal("1E28") };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.math.BigDecimal[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue4 = new java.math.BigDecimal[] { java.math.BigDecimal.ZERO, java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(28, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-28"), new java.math.BigDecimal("1E28") };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.math.BigDecimal[] borderValue4JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue5 = new java.math.BigDecimal[] { null, java.math.BigDecimal.ZERO, java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(28, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-28"), new java.math.BigDecimal("1E28") };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.math.BigDecimal[] borderValue5JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Decimal/OneArrayOfOneDecimalsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Decimal/OneArrayOfOneDecimalsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Decimal;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfOneDecimalsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.math.BigDecimal[] defaultValue = new java.math.BigDecimal[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.math.BigDecimal[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue1 = new java.math.BigDecimal[] { java.math.BigDecimal.ZERO };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.math.BigDecimal[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue2 = new java.math.BigDecimal[] { new java.math.BigDecimal("1E28") };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.math.BigDecimal[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue3 = new java.math.BigDecimal[] { java.math.BigDecimal.ZERO, java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(28, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-28"), new java.math.BigDecimal("1E28") };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.math.BigDecimal[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Decimal/OneDecimalDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Decimal/OneDecimalDefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Decimal;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneDecimalDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.math.BigDecimal defaultValue = java.math.BigDecimal.ZERO;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.math.BigDecimal defaultValueJsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.math.BigDecimal borderValue1 = java.math.BigDecimal.ONE;
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.math.BigDecimal borderValue1JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.math.BigDecimal borderValue2 = new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(28, java.math.BigDecimal.ROUND_HALF_UP);
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.math.BigDecimal borderValue2JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.math.BigDecimal borderValue3 = new java.math.BigDecimal("-1E-28");
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.math.BigDecimal borderValue3JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.math.BigDecimal borderValue4 = new java.math.BigDecimal("1E28");
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.math.BigDecimal borderValue4JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Decimal/OneListOfNullableDecimalsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Decimal/OneListOfNullableDecimalsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Decimal;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfNullableDecimalsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.math.BigDecimal> defaultValue = new java.util.ArrayList<java.math.BigDecimal>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.math.BigDecimal> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue1 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList((java.math.BigDecimal) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.math.BigDecimal> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue2 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.math.BigDecimal> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue3 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(new java.math.BigDecimal("1E28")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.math.BigDecimal> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue4 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO, java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(28, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-28"), new java.math.BigDecimal("1E28")));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<java.math.BigDecimal> borderValue4JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue5 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList((java.math.BigDecimal) null, java.math.BigDecimal.ZERO, java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(28, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-28"), new java.math.BigDecimal("1E28")));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<java.math.BigDecimal> borderValue5JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Decimal/OneListOfOneDecimalsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Decimal/OneListOfOneDecimalsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Decimal;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfOneDecimalsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.math.BigDecimal> defaultValue = new java.util.ArrayList<java.math.BigDecimal>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.math.BigDecimal> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue1 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.math.BigDecimal> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue2 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(new java.math.BigDecimal("1E28")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.math.BigDecimal> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue3 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO, java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(28, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-28"), new java.math.BigDecimal("1E28")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.math.BigDecimal> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Decimal/OneSetOfNullableDecimalsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Decimal/OneSetOfNullableDecimalsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Decimal;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfNullableDecimalsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> defaultValue = new java.util.HashSet<java.math.BigDecimal>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.math.BigDecimal> defaultValueJsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue1 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList((java.math.BigDecimal) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.math.BigDecimal> borderValue1JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue2 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.math.BigDecimal> borderValue2JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue3 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(new java.math.BigDecimal("1E28")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.math.BigDecimal> borderValue3JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue4 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO, java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(28, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-28"), new java.math.BigDecimal("1E28")));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<java.math.BigDecimal> borderValue4JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue5 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList((java.math.BigDecimal) null, java.math.BigDecimal.ZERO, java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(28, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-28"), new java.math.BigDecimal("1E28")));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<java.math.BigDecimal> borderValue5JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Decimal/OneSetOfOneDecimalsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Decimal/OneSetOfOneDecimalsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Decimal;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfOneDecimalsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> defaultValue = new java.util.HashSet<java.math.BigDecimal>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.math.BigDecimal> defaultValueJsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue1 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.math.BigDecimal> borderValue1JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue2 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(new java.math.BigDecimal("1E28")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.math.BigDecimal> borderValue2JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue3 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO, java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(28, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-28"), new java.math.BigDecimal("1E28")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.math.BigDecimal> borderValue3JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalAsserts.assertOneSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/DecimalWithScaleOf9/NullableArrayOfNullableDecimalsWithScaleOf9DefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/DecimalWithScaleOf9/NullableArrayOfNullableDecimalsWithScaleOf9DefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.DecimalWithScaleOf9;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfNullableDecimalsWithScaleOf9DefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.math.BigDecimal[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.math.BigDecimal[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue1 = new java.math.BigDecimal[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.math.BigDecimal[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue2 = new java.math.BigDecimal[] { java.math.BigDecimal.ZERO.setScale(9) };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.math.BigDecimal[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue3 = new java.math.BigDecimal[] { new java.math.BigDecimal("1E19") };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.math.BigDecimal[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue4 = new java.math.BigDecimal[] { java.math.BigDecimal.ZERO.setScale(9), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(9, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-9"), new java.math.BigDecimal("1E19") };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.math.BigDecimal[] borderValue4JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue5 = new java.math.BigDecimal[] { null, java.math.BigDecimal.ZERO.setScale(9), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(9, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-9"), new java.math.BigDecimal("1E19") };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.math.BigDecimal[] borderValue5JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/DecimalWithScaleOf9/NullableArrayOfOneDecimalsWithScaleOf9DefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/DecimalWithScaleOf9/NullableArrayOfOneDecimalsWithScaleOf9DefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.DecimalWithScaleOf9;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfOneDecimalsWithScaleOf9DefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.math.BigDecimal[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.math.BigDecimal[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue1 = new java.math.BigDecimal[] { java.math.BigDecimal.ZERO.setScale(9) };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.math.BigDecimal[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue2 = new java.math.BigDecimal[] { new java.math.BigDecimal("1E19") };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.math.BigDecimal[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue3 = new java.math.BigDecimal[] { java.math.BigDecimal.ZERO.setScale(9), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(9, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-9"), new java.math.BigDecimal("1E19") };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.math.BigDecimal[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/DecimalWithScaleOf9/NullableDecimalWithScaleOf9DefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/DecimalWithScaleOf9/NullableDecimalWithScaleOf9DefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.DecimalWithScaleOf9;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableDecimalWithScaleOf9DefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.math.BigDecimal defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.math.BigDecimal defaultValueJsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.math.BigDecimal borderValue1 = java.math.BigDecimal.ZERO.setScale(9);
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.math.BigDecimal borderValue1JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.math.BigDecimal borderValue2 = java.math.BigDecimal.ONE;
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.math.BigDecimal borderValue2JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.math.BigDecimal borderValue3 = new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(9, java.math.BigDecimal.ROUND_HALF_UP);
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.math.BigDecimal borderValue3JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.math.BigDecimal borderValue4 = new java.math.BigDecimal("-1E-9");
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.math.BigDecimal borderValue4JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.math.BigDecimal borderValue5 = new java.math.BigDecimal("1E19");
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.math.BigDecimal borderValue5JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/DecimalWithScaleOf9/NullableListOfNullableDecimalsWithScaleOf9DefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/DecimalWithScaleOf9/NullableListOfNullableDecimalsWithScaleOf9DefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.DecimalWithScaleOf9;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfNullableDecimalsWithScaleOf9DefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.math.BigDecimal> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.math.BigDecimal> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue1 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList((java.math.BigDecimal) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.math.BigDecimal> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue2 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(9)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.math.BigDecimal> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue3 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(new java.math.BigDecimal("1E19")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.math.BigDecimal> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue4 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(9), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(9, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-9"), new java.math.BigDecimal("1E19")));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<java.math.BigDecimal> borderValue4JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue5 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList((java.math.BigDecimal) null, java.math.BigDecimal.ZERO.setScale(9), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(9, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-9"), new java.math.BigDecimal("1E19")));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<java.math.BigDecimal> borderValue5JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/DecimalWithScaleOf9/NullableListOfOneDecimalsWithScaleOf9DefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/DecimalWithScaleOf9/NullableListOfOneDecimalsWithScaleOf9DefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.DecimalWithScaleOf9;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfOneDecimalsWithScaleOf9DefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.math.BigDecimal> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.math.BigDecimal> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue1 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(9)));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.math.BigDecimal> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue2 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(new java.math.BigDecimal("1E19")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.math.BigDecimal> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue3 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(9), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(9, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-9"), new java.math.BigDecimal("1E19")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.math.BigDecimal> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/DecimalWithScaleOf9/NullableSetOfNullableDecimalsWithScaleOf9DefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/DecimalWithScaleOf9/NullableSetOfNullableDecimalsWithScaleOf9DefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.DecimalWithScaleOf9;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfNullableDecimalsWithScaleOf9DefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.math.BigDecimal> defaultValueJsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue1 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList((java.math.BigDecimal) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.math.BigDecimal> borderValue1JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue2 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(9)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.math.BigDecimal> borderValue2JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue3 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(new java.math.BigDecimal("1E19")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.math.BigDecimal> borderValue3JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue4 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(9), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(9, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-9"), new java.math.BigDecimal("1E19")));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<java.math.BigDecimal> borderValue4JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue5 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList((java.math.BigDecimal) null, java.math.BigDecimal.ZERO.setScale(9), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(9, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-9"), new java.math.BigDecimal("1E19")));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<java.math.BigDecimal> borderValue5JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/DecimalWithScaleOf9/NullableSetOfOneDecimalsWithScaleOf9DefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/DecimalWithScaleOf9/NullableSetOfOneDecimalsWithScaleOf9DefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.DecimalWithScaleOf9;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfOneDecimalsWithScaleOf9DefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.math.BigDecimal> defaultValueJsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue1 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(9)));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.math.BigDecimal> borderValue1JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue2 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(new java.math.BigDecimal("1E19")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.math.BigDecimal> borderValue2JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue3 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(9), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(9, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-9"), new java.math.BigDecimal("1E19")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.math.BigDecimal> borderValue3JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertNullableSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/DecimalWithScaleOf9/OneArrayOfNullableDecimalsWithScaleOf9DefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/DecimalWithScaleOf9/OneArrayOfNullableDecimalsWithScaleOf9DefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.DecimalWithScaleOf9;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfNullableDecimalsWithScaleOf9DefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.math.BigDecimal[] defaultValue = new java.math.BigDecimal[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.math.BigDecimal[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue1 = new java.math.BigDecimal[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.math.BigDecimal[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue2 = new java.math.BigDecimal[] { java.math.BigDecimal.ZERO.setScale(9) };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.math.BigDecimal[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue3 = new java.math.BigDecimal[] { new java.math.BigDecimal("1E19") };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.math.BigDecimal[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue4 = new java.math.BigDecimal[] { java.math.BigDecimal.ZERO.setScale(9), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(9, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-9"), new java.math.BigDecimal("1E19") };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.math.BigDecimal[] borderValue4JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue5 = new java.math.BigDecimal[] { null, java.math.BigDecimal.ZERO.setScale(9), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(9, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-9"), new java.math.BigDecimal("1E19") };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.math.BigDecimal[] borderValue5JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/DecimalWithScaleOf9/OneArrayOfOneDecimalsWithScaleOf9DefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/DecimalWithScaleOf9/OneArrayOfOneDecimalsWithScaleOf9DefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.DecimalWithScaleOf9;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfOneDecimalsWithScaleOf9DefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.math.BigDecimal[] defaultValue = new java.math.BigDecimal[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.math.BigDecimal[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue1 = new java.math.BigDecimal[] { java.math.BigDecimal.ZERO.setScale(9) };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.math.BigDecimal[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue2 = new java.math.BigDecimal[] { new java.math.BigDecimal("1E19") };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.math.BigDecimal[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue3 = new java.math.BigDecimal[] { java.math.BigDecimal.ZERO.setScale(9), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(9, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-9"), new java.math.BigDecimal("1E19") };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.math.BigDecimal[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/DecimalWithScaleOf9/OneDecimalWithScaleOf9DefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/DecimalWithScaleOf9/OneDecimalWithScaleOf9DefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.DecimalWithScaleOf9;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneDecimalWithScaleOf9DefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.math.BigDecimal defaultValue = java.math.BigDecimal.ZERO.setScale(9);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.math.BigDecimal defaultValueJsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.math.BigDecimal borderValue1 = java.math.BigDecimal.ONE;
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.math.BigDecimal borderValue1JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.math.BigDecimal borderValue2 = new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(9, java.math.BigDecimal.ROUND_HALF_UP);
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.math.BigDecimal borderValue2JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.math.BigDecimal borderValue3 = new java.math.BigDecimal("-1E-9");
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.math.BigDecimal borderValue3JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.math.BigDecimal borderValue4 = new java.math.BigDecimal("1E19");
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.math.BigDecimal borderValue4JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/DecimalWithScaleOf9/OneListOfNullableDecimalsWithScaleOf9DefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/DecimalWithScaleOf9/OneListOfNullableDecimalsWithScaleOf9DefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.DecimalWithScaleOf9;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfNullableDecimalsWithScaleOf9DefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.math.BigDecimal> defaultValue = new java.util.ArrayList<java.math.BigDecimal>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.math.BigDecimal> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue1 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList((java.math.BigDecimal) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.math.BigDecimal> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue2 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(9)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.math.BigDecimal> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue3 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(new java.math.BigDecimal("1E19")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.math.BigDecimal> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue4 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(9), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(9, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-9"), new java.math.BigDecimal("1E19")));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<java.math.BigDecimal> borderValue4JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue5 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList((java.math.BigDecimal) null, java.math.BigDecimal.ZERO.setScale(9), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(9, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-9"), new java.math.BigDecimal("1E19")));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<java.math.BigDecimal> borderValue5JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/DecimalWithScaleOf9/OneListOfOneDecimalsWithScaleOf9DefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/DecimalWithScaleOf9/OneListOfOneDecimalsWithScaleOf9DefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.DecimalWithScaleOf9;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfOneDecimalsWithScaleOf9DefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.math.BigDecimal> defaultValue = new java.util.ArrayList<java.math.BigDecimal>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.math.BigDecimal> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue1 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(9)));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.math.BigDecimal> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue2 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(new java.math.BigDecimal("1E19")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.math.BigDecimal> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue3 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(9), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(9, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-9"), new java.math.BigDecimal("1E19")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.math.BigDecimal> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/DecimalWithScaleOf9/OneSetOfNullableDecimalsWithScaleOf9DefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/DecimalWithScaleOf9/OneSetOfNullableDecimalsWithScaleOf9DefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.DecimalWithScaleOf9;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfNullableDecimalsWithScaleOf9DefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> defaultValue = new java.util.HashSet<java.math.BigDecimal>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.math.BigDecimal> defaultValueJsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue1 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList((java.math.BigDecimal) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.math.BigDecimal> borderValue1JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue2 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(9)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.math.BigDecimal> borderValue2JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue3 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(new java.math.BigDecimal("1E19")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.math.BigDecimal> borderValue3JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue4 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(9), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(9, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-9"), new java.math.BigDecimal("1E19")));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<java.math.BigDecimal> borderValue4JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue5 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList((java.math.BigDecimal) null, java.math.BigDecimal.ZERO.setScale(9), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(9, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-9"), new java.math.BigDecimal("1E19")));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<java.math.BigDecimal> borderValue5JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/DecimalWithScaleOf9/OneSetOfOneDecimalsWithScaleOf9DefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/DecimalWithScaleOf9/OneSetOfOneDecimalsWithScaleOf9DefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.DecimalWithScaleOf9;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfOneDecimalsWithScaleOf9DefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> defaultValue = new java.util.HashSet<java.math.BigDecimal>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.math.BigDecimal> defaultValueJsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue1 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(9)));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.math.BigDecimal> borderValue1JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue2 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(new java.math.BigDecimal("1E19")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.math.BigDecimal> borderValue2JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue3 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(9), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(9, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-9"), new java.math.BigDecimal("1E19")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.math.BigDecimal> borderValue3JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DecimalWithScaleOf9Asserts.assertOneSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Double/NullableArrayOfNullableDoublesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Double/NullableArrayOfNullableDoublesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Double;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfNullableDoublesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final Double[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final Double[] defaultValueJsonDeserialized = jsonSerialization.deserialize(Double[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final Double[] borderValue1 = new Double[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final Double[] borderValue1JsonDeserialized = jsonSerialization.deserialize(Double[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final Double[] borderValue2 = new Double[] { 0.0 };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final Double[] borderValue2JsonDeserialized = jsonSerialization.deserialize(Double[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final Double[] borderValue3 = new Double[] { Double.NaN };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final Double[] borderValue3JsonDeserialized = jsonSerialization.deserialize(Double[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final Double[] borderValue4 = new Double[] { 0.0, 1E-307, 9E307, -1.23456789012345E-10, 1.23456789012345E20, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final Double[] borderValue4JsonDeserialized = jsonSerialization.deserialize(Double[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final Double[] borderValue5 = new Double[] { null, 0.0, 1E-307, 9E307, -1.23456789012345E-10, 1.23456789012345E20, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final Double[] borderValue5JsonDeserialized = jsonSerialization.deserialize(Double[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Double/NullableArrayOfOneDoublesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Double/NullableArrayOfOneDoublesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Double;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfOneDoublesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final double[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final double[] defaultValueJsonDeserialized = jsonSerialization.deserialize(double[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final double[] borderValue1 = new double[] { 0.0 };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final double[] borderValue1JsonDeserialized = jsonSerialization.deserialize(double[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final double[] borderValue2 = new double[] { Double.NaN };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final double[] borderValue2JsonDeserialized = jsonSerialization.deserialize(double[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final double[] borderValue3 = new double[] { 0.0, 1E-307, 9E307, -1.23456789012345E-10, 1.23456789012345E20, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final double[] borderValue3JsonDeserialized = jsonSerialization.deserialize(double[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Double/NullableDoubleDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Double/NullableDoubleDefaultValueTurtle.java
@@ -1,0 +1,100 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Double;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableDoubleDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final Double defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final Double defaultValueJsonDeserialized = jsonSerialization.deserialize(Double.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final Double borderValue1 = 0.0;
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final Double borderValue1JsonDeserialized = jsonSerialization.deserialize(Double.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final Double borderValue2 = 1E-307;
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final Double borderValue2JsonDeserialized = jsonSerialization.deserialize(Double.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final Double borderValue3 = 9E307;
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final Double borderValue3JsonDeserialized = jsonSerialization.deserialize(Double.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final Double borderValue4 = -1.23456789012345E-10;
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final Double borderValue4JsonDeserialized = jsonSerialization.deserialize(Double.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final Double borderValue5 = 1.23456789012345E20;
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final Double borderValue5JsonDeserialized = jsonSerialization.deserialize(Double.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue6Equality() throws IOException {
+        final Double borderValue6 = Double.NEGATIVE_INFINITY;
+        final Bytes borderValue6JsonSerialized = jsonSerialization.serialize(borderValue6);
+        final Double borderValue6JsonDeserialized = jsonSerialization.deserialize(Double.class, borderValue6JsonSerialized.content, borderValue6JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableEquals(borderValue6, borderValue6JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue7Equality() throws IOException {
+        final Double borderValue7 = Double.POSITIVE_INFINITY;
+        final Bytes borderValue7JsonSerialized = jsonSerialization.serialize(borderValue7);
+        final Double borderValue7JsonDeserialized = jsonSerialization.deserialize(Double.class, borderValue7JsonSerialized.content, borderValue7JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableEquals(borderValue7, borderValue7JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue8Equality() throws IOException {
+        final Double borderValue8 = Double.NaN;
+        final Bytes borderValue8JsonSerialized = jsonSerialization.serialize(borderValue8);
+        final Double borderValue8JsonDeserialized = jsonSerialization.deserialize(Double.class, borderValue8JsonSerialized.content, borderValue8JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableEquals(borderValue8, borderValue8JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Double/NullableListOfNullableDoublesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Double/NullableListOfNullableDoublesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Double;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfNullableDoublesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<Double> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<Double> defaultValueJsonDeserialized = jsonSerialization.deserializeList(Double.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<Double> borderValue1 = new java.util.ArrayList<Double>(java.util.Arrays.asList((Double) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<Double> borderValue1JsonDeserialized = jsonSerialization.deserializeList(Double.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<Double> borderValue2 = new java.util.ArrayList<Double>(java.util.Arrays.asList(0.0));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<Double> borderValue2JsonDeserialized = jsonSerialization.deserializeList(Double.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<Double> borderValue3 = new java.util.ArrayList<Double>(java.util.Arrays.asList(Double.NaN));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<Double> borderValue3JsonDeserialized = jsonSerialization.deserializeList(Double.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<Double> borderValue4 = new java.util.ArrayList<Double>(java.util.Arrays.asList(0.0, 1E-307, 9E307, -1.23456789012345E-10, 1.23456789012345E20, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<Double> borderValue4JsonDeserialized = jsonSerialization.deserializeList(Double.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<Double> borderValue5 = new java.util.ArrayList<Double>(java.util.Arrays.asList((Double) null, 0.0, 1E-307, 9E307, -1.23456789012345E-10, 1.23456789012345E20, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<Double> borderValue5JsonDeserialized = jsonSerialization.deserializeList(Double.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Double/NullableListOfOneDoublesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Double/NullableListOfOneDoublesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Double;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfOneDoublesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<Double> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<Double> defaultValueJsonDeserialized = jsonSerialization.deserializeList(Double.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<Double> borderValue1 = new java.util.ArrayList<Double>(java.util.Arrays.asList(0.0));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<Double> borderValue1JsonDeserialized = jsonSerialization.deserializeList(Double.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<Double> borderValue2 = new java.util.ArrayList<Double>(java.util.Arrays.asList(Double.NaN));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<Double> borderValue2JsonDeserialized = jsonSerialization.deserializeList(Double.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<Double> borderValue3 = new java.util.ArrayList<Double>(java.util.Arrays.asList(0.0, 1E-307, 9E307, -1.23456789012345E-10, 1.23456789012345E20, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<Double> borderValue3JsonDeserialized = jsonSerialization.deserializeList(Double.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Double/NullableSetOfNullableDoublesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Double/NullableSetOfNullableDoublesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Double;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfNullableDoublesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<Double> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<Double> defaultValueJsonDeserialized = new java.util.HashSet<Double>(jsonSerialization.deserializeList(Double.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<Double> borderValue1 = new java.util.HashSet<Double>(java.util.Arrays.asList((Double) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<Double> borderValue1JsonDeserialized = new java.util.HashSet<Double>(jsonSerialization.deserializeList(Double.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<Double> borderValue2 = new java.util.HashSet<Double>(java.util.Arrays.asList(0.0));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<Double> borderValue2JsonDeserialized = new java.util.HashSet<Double>(jsonSerialization.deserializeList(Double.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<Double> borderValue3 = new java.util.HashSet<Double>(java.util.Arrays.asList(Double.NaN));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<Double> borderValue3JsonDeserialized = new java.util.HashSet<Double>(jsonSerialization.deserializeList(Double.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<Double> borderValue4 = new java.util.HashSet<Double>(java.util.Arrays.asList(0.0, 1E-307, 9E307, -1.23456789012345E-10, 1.23456789012345E20, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<Double> borderValue4JsonDeserialized = new java.util.HashSet<Double>(jsonSerialization.deserializeList(Double.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<Double> borderValue5 = new java.util.HashSet<Double>(java.util.Arrays.asList((Double) null, 0.0, 1E-307, 9E307, -1.23456789012345E-10, 1.23456789012345E20, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<Double> borderValue5JsonDeserialized = new java.util.HashSet<Double>(jsonSerialization.deserializeList(Double.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Double/NullableSetOfOneDoublesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Double/NullableSetOfOneDoublesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Double;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfOneDoublesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<Double> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<Double> defaultValueJsonDeserialized = new java.util.HashSet<Double>(jsonSerialization.deserializeList(Double.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<Double> borderValue1 = new java.util.HashSet<Double>(java.util.Arrays.asList(0.0));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<Double> borderValue1JsonDeserialized = new java.util.HashSet<Double>(jsonSerialization.deserializeList(Double.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<Double> borderValue2 = new java.util.HashSet<Double>(java.util.Arrays.asList(Double.NaN));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<Double> borderValue2JsonDeserialized = new java.util.HashSet<Double>(jsonSerialization.deserializeList(Double.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<Double> borderValue3 = new java.util.HashSet<Double>(java.util.Arrays.asList(0.0, 1E-307, 9E307, -1.23456789012345E-10, 1.23456789012345E20, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<Double> borderValue3JsonDeserialized = new java.util.HashSet<Double>(jsonSerialization.deserializeList(Double.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertNullableSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Double/OneArrayOfNullableDoublesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Double/OneArrayOfNullableDoublesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Double;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfNullableDoublesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final Double[] defaultValue = new Double[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final Double[] defaultValueJsonDeserialized = jsonSerialization.deserialize(Double[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final Double[] borderValue1 = new Double[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final Double[] borderValue1JsonDeserialized = jsonSerialization.deserialize(Double[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final Double[] borderValue2 = new Double[] { 0.0 };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final Double[] borderValue2JsonDeserialized = jsonSerialization.deserialize(Double[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final Double[] borderValue3 = new Double[] { Double.NaN };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final Double[] borderValue3JsonDeserialized = jsonSerialization.deserialize(Double[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final Double[] borderValue4 = new Double[] { 0.0, 1E-307, 9E307, -1.23456789012345E-10, 1.23456789012345E20, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final Double[] borderValue4JsonDeserialized = jsonSerialization.deserialize(Double[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final Double[] borderValue5 = new Double[] { null, 0.0, 1E-307, 9E307, -1.23456789012345E-10, 1.23456789012345E20, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final Double[] borderValue5JsonDeserialized = jsonSerialization.deserialize(Double[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Double/OneArrayOfOneDoublesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Double/OneArrayOfOneDoublesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Double;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfOneDoublesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final double[] defaultValue = new double[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final double[] defaultValueJsonDeserialized = jsonSerialization.deserialize(double[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final double[] borderValue1 = new double[] { 0.0 };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final double[] borderValue1JsonDeserialized = jsonSerialization.deserialize(double[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final double[] borderValue2 = new double[] { Double.NaN };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final double[] borderValue2JsonDeserialized = jsonSerialization.deserialize(double[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final double[] borderValue3 = new double[] { 0.0, 1E-307, 9E307, -1.23456789012345E-10, 1.23456789012345E20, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final double[] borderValue3JsonDeserialized = jsonSerialization.deserialize(double[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Double/OneDoubleDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Double/OneDoubleDefaultValueTurtle.java
@@ -1,0 +1,91 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Double;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneDoubleDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final double defaultValue = 0.0;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final double defaultValueJsonDeserialized = jsonSerialization.deserialize(double.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final double borderValue1 = 1E-307;
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final double borderValue1JsonDeserialized = jsonSerialization.deserialize(double.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final double borderValue2 = 9E307;
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final double borderValue2JsonDeserialized = jsonSerialization.deserialize(double.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final double borderValue3 = -1.23456789012345E-10;
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final double borderValue3JsonDeserialized = jsonSerialization.deserialize(double.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final double borderValue4 = 1.23456789012345E20;
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final double borderValue4JsonDeserialized = jsonSerialization.deserialize(double.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final double borderValue5 = Double.NEGATIVE_INFINITY;
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final double borderValue5JsonDeserialized = jsonSerialization.deserialize(double.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue6Equality() throws IOException {
+        final double borderValue6 = Double.POSITIVE_INFINITY;
+        final Bytes borderValue6JsonSerialized = jsonSerialization.serialize(borderValue6);
+        final double borderValue6JsonDeserialized = jsonSerialization.deserialize(double.class, borderValue6JsonSerialized.content, borderValue6JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneEquals(borderValue6, borderValue6JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue7Equality() throws IOException {
+        final double borderValue7 = Double.NaN;
+        final Bytes borderValue7JsonSerialized = jsonSerialization.serialize(borderValue7);
+        final double borderValue7JsonDeserialized = jsonSerialization.deserialize(double.class, borderValue7JsonSerialized.content, borderValue7JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneEquals(borderValue7, borderValue7JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Double/OneListOfNullableDoublesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Double/OneListOfNullableDoublesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Double;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfNullableDoublesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<Double> defaultValue = new java.util.ArrayList<Double>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<Double> defaultValueJsonDeserialized = jsonSerialization.deserializeList(Double.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<Double> borderValue1 = new java.util.ArrayList<Double>(java.util.Arrays.asList((Double) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<Double> borderValue1JsonDeserialized = jsonSerialization.deserializeList(Double.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<Double> borderValue2 = new java.util.ArrayList<Double>(java.util.Arrays.asList(0.0));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<Double> borderValue2JsonDeserialized = jsonSerialization.deserializeList(Double.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<Double> borderValue3 = new java.util.ArrayList<Double>(java.util.Arrays.asList(Double.NaN));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<Double> borderValue3JsonDeserialized = jsonSerialization.deserializeList(Double.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<Double> borderValue4 = new java.util.ArrayList<Double>(java.util.Arrays.asList(0.0, 1E-307, 9E307, -1.23456789012345E-10, 1.23456789012345E20, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<Double> borderValue4JsonDeserialized = jsonSerialization.deserializeList(Double.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<Double> borderValue5 = new java.util.ArrayList<Double>(java.util.Arrays.asList((Double) null, 0.0, 1E-307, 9E307, -1.23456789012345E-10, 1.23456789012345E20, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<Double> borderValue5JsonDeserialized = jsonSerialization.deserializeList(Double.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Double/OneListOfOneDoublesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Double/OneListOfOneDoublesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Double;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfOneDoublesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<Double> defaultValue = new java.util.ArrayList<Double>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<Double> defaultValueJsonDeserialized = jsonSerialization.deserializeList(Double.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<Double> borderValue1 = new java.util.ArrayList<Double>(java.util.Arrays.asList(0.0));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<Double> borderValue1JsonDeserialized = jsonSerialization.deserializeList(Double.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<Double> borderValue2 = new java.util.ArrayList<Double>(java.util.Arrays.asList(Double.NaN));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<Double> borderValue2JsonDeserialized = jsonSerialization.deserializeList(Double.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<Double> borderValue3 = new java.util.ArrayList<Double>(java.util.Arrays.asList(0.0, 1E-307, 9E307, -1.23456789012345E-10, 1.23456789012345E20, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<Double> borderValue3JsonDeserialized = jsonSerialization.deserializeList(Double.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Double/OneSetOfNullableDoublesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Double/OneSetOfNullableDoublesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Double;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfNullableDoublesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<Double> defaultValue = new java.util.HashSet<Double>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<Double> defaultValueJsonDeserialized = new java.util.HashSet<Double>(jsonSerialization.deserializeList(Double.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<Double> borderValue1 = new java.util.HashSet<Double>(java.util.Arrays.asList((Double) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<Double> borderValue1JsonDeserialized = new java.util.HashSet<Double>(jsonSerialization.deserializeList(Double.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<Double> borderValue2 = new java.util.HashSet<Double>(java.util.Arrays.asList(0.0));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<Double> borderValue2JsonDeserialized = new java.util.HashSet<Double>(jsonSerialization.deserializeList(Double.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<Double> borderValue3 = new java.util.HashSet<Double>(java.util.Arrays.asList(Double.NaN));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<Double> borderValue3JsonDeserialized = new java.util.HashSet<Double>(jsonSerialization.deserializeList(Double.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<Double> borderValue4 = new java.util.HashSet<Double>(java.util.Arrays.asList(0.0, 1E-307, 9E307, -1.23456789012345E-10, 1.23456789012345E20, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<Double> borderValue4JsonDeserialized = new java.util.HashSet<Double>(jsonSerialization.deserializeList(Double.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<Double> borderValue5 = new java.util.HashSet<Double>(java.util.Arrays.asList((Double) null, 0.0, 1E-307, 9E307, -1.23456789012345E-10, 1.23456789012345E20, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<Double> borderValue5JsonDeserialized = new java.util.HashSet<Double>(jsonSerialization.deserializeList(Double.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Double/OneSetOfOneDoublesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Double/OneSetOfOneDoublesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Double;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfOneDoublesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<Double> defaultValue = new java.util.HashSet<Double>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<Double> defaultValueJsonDeserialized = new java.util.HashSet<Double>(jsonSerialization.deserializeList(Double.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<Double> borderValue1 = new java.util.HashSet<Double>(java.util.Arrays.asList(0.0));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<Double> borderValue1JsonDeserialized = new java.util.HashSet<Double>(jsonSerialization.deserializeList(Double.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<Double> borderValue2 = new java.util.HashSet<Double>(java.util.Arrays.asList(Double.NaN));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<Double> borderValue2JsonDeserialized = new java.util.HashSet<Double>(jsonSerialization.deserializeList(Double.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<Double> borderValue3 = new java.util.HashSet<Double>(java.util.Arrays.asList(0.0, 1E-307, 9E307, -1.23456789012345E-10, 1.23456789012345E20, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<Double> borderValue3JsonDeserialized = new java.util.HashSet<Double>(jsonSerialization.deserializeList(Double.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.DoubleAsserts.assertOneSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Float/NullableArrayOfNullableFloatsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Float/NullableArrayOfNullableFloatsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Float;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfNullableFloatsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final Float[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final Float[] defaultValueJsonDeserialized = jsonSerialization.deserialize(Float[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final Float[] borderValue1 = new Float[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final Float[] borderValue1JsonDeserialized = jsonSerialization.deserialize(Float[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final Float[] borderValue2 = new Float[] { 0.0f };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final Float[] borderValue2JsonDeserialized = jsonSerialization.deserialize(Float[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final Float[] borderValue3 = new Float[] { Float.POSITIVE_INFINITY };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final Float[] borderValue3JsonDeserialized = jsonSerialization.deserialize(Float[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final Float[] borderValue4 = new Float[] { 0.0f, -1.2345E-10f, 1.2345E20f, -1E-5f, Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final Float[] borderValue4JsonDeserialized = jsonSerialization.deserialize(Float[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final Float[] borderValue5 = new Float[] { null, 0.0f, -1.2345E-10f, 1.2345E20f, -1E-5f, Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final Float[] borderValue5JsonDeserialized = jsonSerialization.deserialize(Float[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Float/NullableArrayOfOneFloatsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Float/NullableArrayOfOneFloatsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Float;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfOneFloatsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final float[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final float[] defaultValueJsonDeserialized = jsonSerialization.deserialize(float[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final float[] borderValue1 = new float[] { 0.0f };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final float[] borderValue1JsonDeserialized = jsonSerialization.deserialize(float[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final float[] borderValue2 = new float[] { Float.POSITIVE_INFINITY };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final float[] borderValue2JsonDeserialized = jsonSerialization.deserialize(float[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final float[] borderValue3 = new float[] { 0.0f, -1.2345E-10f, 1.2345E20f, -1E-5f, Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final float[] borderValue3JsonDeserialized = jsonSerialization.deserialize(float[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Float/NullableFloatDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Float/NullableFloatDefaultValueTurtle.java
@@ -1,0 +1,91 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Float;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableFloatDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final Float defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final Float defaultValueJsonDeserialized = jsonSerialization.deserialize(Float.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final Float borderValue1 = 0.0f;
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final Float borderValue1JsonDeserialized = jsonSerialization.deserialize(Float.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final Float borderValue2 = -1.2345E-10f;
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final Float borderValue2JsonDeserialized = jsonSerialization.deserialize(Float.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final Float borderValue3 = 1.2345E20f;
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final Float borderValue3JsonDeserialized = jsonSerialization.deserialize(Float.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final Float borderValue4 = -1E-5f;
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final Float borderValue4JsonDeserialized = jsonSerialization.deserialize(Float.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final Float borderValue5 = Float.NaN;
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final Float borderValue5JsonDeserialized = jsonSerialization.deserialize(Float.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue6Equality() throws IOException {
+        final Float borderValue6 = Float.NEGATIVE_INFINITY;
+        final Bytes borderValue6JsonSerialized = jsonSerialization.serialize(borderValue6);
+        final Float borderValue6JsonDeserialized = jsonSerialization.deserialize(Float.class, borderValue6JsonSerialized.content, borderValue6JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableEquals(borderValue6, borderValue6JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue7Equality() throws IOException {
+        final Float borderValue7 = Float.POSITIVE_INFINITY;
+        final Bytes borderValue7JsonSerialized = jsonSerialization.serialize(borderValue7);
+        final Float borderValue7JsonDeserialized = jsonSerialization.deserialize(Float.class, borderValue7JsonSerialized.content, borderValue7JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableEquals(borderValue7, borderValue7JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Float/NullableListOfNullableFloatsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Float/NullableListOfNullableFloatsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Float;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfNullableFloatsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<Float> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<Float> defaultValueJsonDeserialized = jsonSerialization.deserializeList(Float.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<Float> borderValue1 = new java.util.ArrayList<Float>(java.util.Arrays.asList((Float) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<Float> borderValue1JsonDeserialized = jsonSerialization.deserializeList(Float.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<Float> borderValue2 = new java.util.ArrayList<Float>(java.util.Arrays.asList(0.0f));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<Float> borderValue2JsonDeserialized = jsonSerialization.deserializeList(Float.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<Float> borderValue3 = new java.util.ArrayList<Float>(java.util.Arrays.asList(Float.POSITIVE_INFINITY));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<Float> borderValue3JsonDeserialized = jsonSerialization.deserializeList(Float.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<Float> borderValue4 = new java.util.ArrayList<Float>(java.util.Arrays.asList(0.0f, -1.2345E-10f, 1.2345E20f, -1E-5f, Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<Float> borderValue4JsonDeserialized = jsonSerialization.deserializeList(Float.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<Float> borderValue5 = new java.util.ArrayList<Float>(java.util.Arrays.asList((Float) null, 0.0f, -1.2345E-10f, 1.2345E20f, -1E-5f, Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<Float> borderValue5JsonDeserialized = jsonSerialization.deserializeList(Float.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Float/NullableListOfOneFloatsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Float/NullableListOfOneFloatsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Float;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfOneFloatsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<Float> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<Float> defaultValueJsonDeserialized = jsonSerialization.deserializeList(Float.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<Float> borderValue1 = new java.util.ArrayList<Float>(java.util.Arrays.asList(0.0f));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<Float> borderValue1JsonDeserialized = jsonSerialization.deserializeList(Float.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<Float> borderValue2 = new java.util.ArrayList<Float>(java.util.Arrays.asList(Float.POSITIVE_INFINITY));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<Float> borderValue2JsonDeserialized = jsonSerialization.deserializeList(Float.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<Float> borderValue3 = new java.util.ArrayList<Float>(java.util.Arrays.asList(0.0f, -1.2345E-10f, 1.2345E20f, -1E-5f, Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<Float> borderValue3JsonDeserialized = jsonSerialization.deserializeList(Float.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Float/NullableSetOfNullableFloatsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Float/NullableSetOfNullableFloatsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Float;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfNullableFloatsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<Float> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<Float> defaultValueJsonDeserialized = new java.util.HashSet<Float>(jsonSerialization.deserializeList(Float.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<Float> borderValue1 = new java.util.HashSet<Float>(java.util.Arrays.asList((Float) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<Float> borderValue1JsonDeserialized = new java.util.HashSet<Float>(jsonSerialization.deserializeList(Float.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<Float> borderValue2 = new java.util.HashSet<Float>(java.util.Arrays.asList(0.0f));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<Float> borderValue2JsonDeserialized = new java.util.HashSet<Float>(jsonSerialization.deserializeList(Float.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<Float> borderValue3 = new java.util.HashSet<Float>(java.util.Arrays.asList(Float.POSITIVE_INFINITY));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<Float> borderValue3JsonDeserialized = new java.util.HashSet<Float>(jsonSerialization.deserializeList(Float.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<Float> borderValue4 = new java.util.HashSet<Float>(java.util.Arrays.asList(0.0f, -1.2345E-10f, 1.2345E20f, -1E-5f, Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<Float> borderValue4JsonDeserialized = new java.util.HashSet<Float>(jsonSerialization.deserializeList(Float.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<Float> borderValue5 = new java.util.HashSet<Float>(java.util.Arrays.asList((Float) null, 0.0f, -1.2345E-10f, 1.2345E20f, -1E-5f, Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<Float> borderValue5JsonDeserialized = new java.util.HashSet<Float>(jsonSerialization.deserializeList(Float.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Float/NullableSetOfOneFloatsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Float/NullableSetOfOneFloatsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Float;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfOneFloatsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<Float> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<Float> defaultValueJsonDeserialized = new java.util.HashSet<Float>(jsonSerialization.deserializeList(Float.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<Float> borderValue1 = new java.util.HashSet<Float>(java.util.Arrays.asList(0.0f));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<Float> borderValue1JsonDeserialized = new java.util.HashSet<Float>(jsonSerialization.deserializeList(Float.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<Float> borderValue2 = new java.util.HashSet<Float>(java.util.Arrays.asList(Float.POSITIVE_INFINITY));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<Float> borderValue2JsonDeserialized = new java.util.HashSet<Float>(jsonSerialization.deserializeList(Float.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<Float> borderValue3 = new java.util.HashSet<Float>(java.util.Arrays.asList(0.0f, -1.2345E-10f, 1.2345E20f, -1E-5f, Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<Float> borderValue3JsonDeserialized = new java.util.HashSet<Float>(jsonSerialization.deserializeList(Float.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertNullableSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Float/OneArrayOfNullableFloatsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Float/OneArrayOfNullableFloatsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Float;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfNullableFloatsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final Float[] defaultValue = new Float[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final Float[] defaultValueJsonDeserialized = jsonSerialization.deserialize(Float[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final Float[] borderValue1 = new Float[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final Float[] borderValue1JsonDeserialized = jsonSerialization.deserialize(Float[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final Float[] borderValue2 = new Float[] { 0.0f };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final Float[] borderValue2JsonDeserialized = jsonSerialization.deserialize(Float[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final Float[] borderValue3 = new Float[] { Float.POSITIVE_INFINITY };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final Float[] borderValue3JsonDeserialized = jsonSerialization.deserialize(Float[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final Float[] borderValue4 = new Float[] { 0.0f, -1.2345E-10f, 1.2345E20f, -1E-5f, Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final Float[] borderValue4JsonDeserialized = jsonSerialization.deserialize(Float[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final Float[] borderValue5 = new Float[] { null, 0.0f, -1.2345E-10f, 1.2345E20f, -1E-5f, Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final Float[] borderValue5JsonDeserialized = jsonSerialization.deserialize(Float[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Float/OneArrayOfOneFloatsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Float/OneArrayOfOneFloatsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Float;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfOneFloatsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final float[] defaultValue = new float[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final float[] defaultValueJsonDeserialized = jsonSerialization.deserialize(float[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final float[] borderValue1 = new float[] { 0.0f };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final float[] borderValue1JsonDeserialized = jsonSerialization.deserialize(float[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final float[] borderValue2 = new float[] { Float.POSITIVE_INFINITY };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final float[] borderValue2JsonDeserialized = jsonSerialization.deserialize(float[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final float[] borderValue3 = new float[] { 0.0f, -1.2345E-10f, 1.2345E20f, -1E-5f, Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final float[] borderValue3JsonDeserialized = jsonSerialization.deserialize(float[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Float/OneFloatDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Float/OneFloatDefaultValueTurtle.java
@@ -1,0 +1,82 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Float;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneFloatDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final float defaultValue = 0.0f;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final float defaultValueJsonDeserialized = jsonSerialization.deserialize(float.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final float borderValue1 = -1.2345E-10f;
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final float borderValue1JsonDeserialized = jsonSerialization.deserialize(float.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final float borderValue2 = 1.2345E20f;
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final float borderValue2JsonDeserialized = jsonSerialization.deserialize(float.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final float borderValue3 = -1E-5f;
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final float borderValue3JsonDeserialized = jsonSerialization.deserialize(float.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final float borderValue4 = Float.NaN;
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final float borderValue4JsonDeserialized = jsonSerialization.deserialize(float.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final float borderValue5 = Float.NEGATIVE_INFINITY;
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final float borderValue5JsonDeserialized = jsonSerialization.deserialize(float.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue6Equality() throws IOException {
+        final float borderValue6 = Float.POSITIVE_INFINITY;
+        final Bytes borderValue6JsonSerialized = jsonSerialization.serialize(borderValue6);
+        final float borderValue6JsonDeserialized = jsonSerialization.deserialize(float.class, borderValue6JsonSerialized.content, borderValue6JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneEquals(borderValue6, borderValue6JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Float/OneListOfNullableFloatsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Float/OneListOfNullableFloatsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Float;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfNullableFloatsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<Float> defaultValue = new java.util.ArrayList<Float>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<Float> defaultValueJsonDeserialized = jsonSerialization.deserializeList(Float.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<Float> borderValue1 = new java.util.ArrayList<Float>(java.util.Arrays.asList((Float) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<Float> borderValue1JsonDeserialized = jsonSerialization.deserializeList(Float.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<Float> borderValue2 = new java.util.ArrayList<Float>(java.util.Arrays.asList(0.0f));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<Float> borderValue2JsonDeserialized = jsonSerialization.deserializeList(Float.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<Float> borderValue3 = new java.util.ArrayList<Float>(java.util.Arrays.asList(Float.POSITIVE_INFINITY));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<Float> borderValue3JsonDeserialized = jsonSerialization.deserializeList(Float.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<Float> borderValue4 = new java.util.ArrayList<Float>(java.util.Arrays.asList(0.0f, -1.2345E-10f, 1.2345E20f, -1E-5f, Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<Float> borderValue4JsonDeserialized = jsonSerialization.deserializeList(Float.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<Float> borderValue5 = new java.util.ArrayList<Float>(java.util.Arrays.asList((Float) null, 0.0f, -1.2345E-10f, 1.2345E20f, -1E-5f, Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<Float> borderValue5JsonDeserialized = jsonSerialization.deserializeList(Float.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Float/OneListOfOneFloatsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Float/OneListOfOneFloatsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Float;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfOneFloatsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<Float> defaultValue = new java.util.ArrayList<Float>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<Float> defaultValueJsonDeserialized = jsonSerialization.deserializeList(Float.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<Float> borderValue1 = new java.util.ArrayList<Float>(java.util.Arrays.asList(0.0f));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<Float> borderValue1JsonDeserialized = jsonSerialization.deserializeList(Float.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<Float> borderValue2 = new java.util.ArrayList<Float>(java.util.Arrays.asList(Float.POSITIVE_INFINITY));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<Float> borderValue2JsonDeserialized = jsonSerialization.deserializeList(Float.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<Float> borderValue3 = new java.util.ArrayList<Float>(java.util.Arrays.asList(0.0f, -1.2345E-10f, 1.2345E20f, -1E-5f, Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<Float> borderValue3JsonDeserialized = jsonSerialization.deserializeList(Float.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Float/OneSetOfNullableFloatsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Float/OneSetOfNullableFloatsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Float;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfNullableFloatsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<Float> defaultValue = new java.util.HashSet<Float>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<Float> defaultValueJsonDeserialized = new java.util.HashSet<Float>(jsonSerialization.deserializeList(Float.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<Float> borderValue1 = new java.util.HashSet<Float>(java.util.Arrays.asList((Float) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<Float> borderValue1JsonDeserialized = new java.util.HashSet<Float>(jsonSerialization.deserializeList(Float.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<Float> borderValue2 = new java.util.HashSet<Float>(java.util.Arrays.asList(0.0f));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<Float> borderValue2JsonDeserialized = new java.util.HashSet<Float>(jsonSerialization.deserializeList(Float.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<Float> borderValue3 = new java.util.HashSet<Float>(java.util.Arrays.asList(Float.POSITIVE_INFINITY));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<Float> borderValue3JsonDeserialized = new java.util.HashSet<Float>(jsonSerialization.deserializeList(Float.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<Float> borderValue4 = new java.util.HashSet<Float>(java.util.Arrays.asList(0.0f, -1.2345E-10f, 1.2345E20f, -1E-5f, Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<Float> borderValue4JsonDeserialized = new java.util.HashSet<Float>(jsonSerialization.deserializeList(Float.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<Float> borderValue5 = new java.util.HashSet<Float>(java.util.Arrays.asList((Float) null, 0.0f, -1.2345E-10f, 1.2345E20f, -1E-5f, Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<Float> borderValue5JsonDeserialized = new java.util.HashSet<Float>(jsonSerialization.deserializeList(Float.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Float/OneSetOfOneFloatsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Float/OneSetOfOneFloatsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Float;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfOneFloatsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<Float> defaultValue = new java.util.HashSet<Float>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<Float> defaultValueJsonDeserialized = new java.util.HashSet<Float>(jsonSerialization.deserializeList(Float.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<Float> borderValue1 = new java.util.HashSet<Float>(java.util.Arrays.asList(0.0f));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<Float> borderValue1JsonDeserialized = new java.util.HashSet<Float>(jsonSerialization.deserializeList(Float.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<Float> borderValue2 = new java.util.HashSet<Float>(java.util.Arrays.asList(Float.POSITIVE_INFINITY));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<Float> borderValue2JsonDeserialized = new java.util.HashSet<Float>(jsonSerialization.deserializeList(Float.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<Float> borderValue3 = new java.util.HashSet<Float>(java.util.Arrays.asList(0.0f, -1.2345E-10f, 1.2345E20f, -1E-5f, Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<Float> borderValue3JsonDeserialized = new java.util.HashSet<Float>(jsonSerialization.deserializeList(Float.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.FloatAsserts.assertOneSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Guid/NullableArrayOfNullableGuidsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Guid/NullableArrayOfNullableGuidsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Guid;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfNullableGuidsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.UUID[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.UUID[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.util.UUID[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.UUID[] borderValue1 = new java.util.UUID[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.UUID[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.util.UUID[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.UUID[] borderValue2 = new java.util.UUID[] { java.util.UUID.randomUUID() };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.UUID[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.util.UUID[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.UUID[] borderValue3 = new java.util.UUID[] { new java.util.UUID(0L, 0L) };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.UUID[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.util.UUID[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.UUID[] borderValue4 = new java.util.UUID[] { java.util.UUID.randomUUID(), java.util.UUID.fromString("1-2-3-4-5"), new java.util.UUID(0L, 0L) };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.UUID[] borderValue4JsonDeserialized = jsonSerialization.deserialize(java.util.UUID[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.UUID[] borderValue5 = new java.util.UUID[] { null, java.util.UUID.randomUUID(), java.util.UUID.fromString("1-2-3-4-5"), new java.util.UUID(0L, 0L) };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.UUID[] borderValue5JsonDeserialized = jsonSerialization.deserialize(java.util.UUID[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Guid/NullableArrayOfOneGuidsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Guid/NullableArrayOfOneGuidsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Guid;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfOneGuidsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.UUID[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.UUID[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.util.UUID[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.UUID[] borderValue1 = new java.util.UUID[] { java.util.UUID.randomUUID() };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.UUID[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.util.UUID[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.UUID[] borderValue2 = new java.util.UUID[] { new java.util.UUID(0L, 0L) };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.UUID[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.util.UUID[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.UUID[] borderValue3 = new java.util.UUID[] { java.util.UUID.randomUUID(), java.util.UUID.fromString("1-2-3-4-5"), new java.util.UUID(0L, 0L) };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.UUID[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.util.UUID[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Guid/NullableGuidDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Guid/NullableGuidDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Guid;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableGuidDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.UUID defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.UUID defaultValueJsonDeserialized = jsonSerialization.deserialize(java.util.UUID.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.UUID borderValue1 = java.util.UUID.randomUUID();
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.UUID borderValue1JsonDeserialized = jsonSerialization.deserialize(java.util.UUID.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.UUID borderValue2 = java.util.UUID.fromString("1-2-3-4-5");
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.UUID borderValue2JsonDeserialized = jsonSerialization.deserialize(java.util.UUID.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.UUID borderValue3 = new java.util.UUID(0L, 0L);
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.UUID borderValue3JsonDeserialized = jsonSerialization.deserialize(java.util.UUID.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Guid/NullableListOfNullableGuidsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Guid/NullableListOfNullableGuidsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Guid;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfNullableGuidsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.util.UUID> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.util.UUID> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.util.UUID.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.util.UUID> borderValue1 = new java.util.ArrayList<java.util.UUID>(java.util.Arrays.asList((java.util.UUID) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.util.UUID> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.util.UUID.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.util.UUID> borderValue2 = new java.util.ArrayList<java.util.UUID>(java.util.Arrays.asList(java.util.UUID.randomUUID()));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.util.UUID> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.util.UUID.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.util.UUID> borderValue3 = new java.util.ArrayList<java.util.UUID>(java.util.Arrays.asList(new java.util.UUID(0L, 0L)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.util.UUID> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.util.UUID.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<java.util.UUID> borderValue4 = new java.util.ArrayList<java.util.UUID>(java.util.Arrays.asList(java.util.UUID.randomUUID(), java.util.UUID.fromString("1-2-3-4-5"), new java.util.UUID(0L, 0L)));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<java.util.UUID> borderValue4JsonDeserialized = jsonSerialization.deserializeList(java.util.UUID.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<java.util.UUID> borderValue5 = new java.util.ArrayList<java.util.UUID>(java.util.Arrays.asList((java.util.UUID) null, java.util.UUID.randomUUID(), java.util.UUID.fromString("1-2-3-4-5"), new java.util.UUID(0L, 0L)));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<java.util.UUID> borderValue5JsonDeserialized = jsonSerialization.deserializeList(java.util.UUID.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Guid/NullableListOfOneGuidsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Guid/NullableListOfOneGuidsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Guid;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfOneGuidsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.util.UUID> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.util.UUID> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.util.UUID.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.util.UUID> borderValue1 = new java.util.ArrayList<java.util.UUID>(java.util.Arrays.asList(java.util.UUID.randomUUID()));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.util.UUID> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.util.UUID.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.util.UUID> borderValue2 = new java.util.ArrayList<java.util.UUID>(java.util.Arrays.asList(new java.util.UUID(0L, 0L)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.util.UUID> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.util.UUID.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.util.UUID> borderValue3 = new java.util.ArrayList<java.util.UUID>(java.util.Arrays.asList(java.util.UUID.randomUUID(), java.util.UUID.fromString("1-2-3-4-5"), new java.util.UUID(0L, 0L)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.util.UUID> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.util.UUID.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Guid/NullableSetOfNullableGuidsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Guid/NullableSetOfNullableGuidsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Guid;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfNullableGuidsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.util.UUID> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.util.UUID> defaultValueJsonDeserialized = new java.util.HashSet<java.util.UUID>(jsonSerialization.deserializeList(java.util.UUID.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.util.UUID> borderValue1 = new java.util.HashSet<java.util.UUID>(java.util.Arrays.asList((java.util.UUID) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.util.UUID> borderValue1JsonDeserialized = new java.util.HashSet<java.util.UUID>(jsonSerialization.deserializeList(java.util.UUID.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.util.UUID> borderValue2 = new java.util.HashSet<java.util.UUID>(java.util.Arrays.asList(java.util.UUID.randomUUID()));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.util.UUID> borderValue2JsonDeserialized = new java.util.HashSet<java.util.UUID>(jsonSerialization.deserializeList(java.util.UUID.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.util.UUID> borderValue3 = new java.util.HashSet<java.util.UUID>(java.util.Arrays.asList(new java.util.UUID(0L, 0L)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.util.UUID> borderValue3JsonDeserialized = new java.util.HashSet<java.util.UUID>(jsonSerialization.deserializeList(java.util.UUID.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<java.util.UUID> borderValue4 = new java.util.HashSet<java.util.UUID>(java.util.Arrays.asList(java.util.UUID.randomUUID(), java.util.UUID.fromString("1-2-3-4-5"), new java.util.UUID(0L, 0L)));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<java.util.UUID> borderValue4JsonDeserialized = new java.util.HashSet<java.util.UUID>(jsonSerialization.deserializeList(java.util.UUID.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<java.util.UUID> borderValue5 = new java.util.HashSet<java.util.UUID>(java.util.Arrays.asList((java.util.UUID) null, java.util.UUID.randomUUID(), java.util.UUID.fromString("1-2-3-4-5"), new java.util.UUID(0L, 0L)));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<java.util.UUID> borderValue5JsonDeserialized = new java.util.HashSet<java.util.UUID>(jsonSerialization.deserializeList(java.util.UUID.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Guid/NullableSetOfOneGuidsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Guid/NullableSetOfOneGuidsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Guid;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfOneGuidsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.util.UUID> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.util.UUID> defaultValueJsonDeserialized = new java.util.HashSet<java.util.UUID>(jsonSerialization.deserializeList(java.util.UUID.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.util.UUID> borderValue1 = new java.util.HashSet<java.util.UUID>(java.util.Arrays.asList(java.util.UUID.randomUUID()));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.util.UUID> borderValue1JsonDeserialized = new java.util.HashSet<java.util.UUID>(jsonSerialization.deserializeList(java.util.UUID.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.util.UUID> borderValue2 = new java.util.HashSet<java.util.UUID>(java.util.Arrays.asList(new java.util.UUID(0L, 0L)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.util.UUID> borderValue2JsonDeserialized = new java.util.HashSet<java.util.UUID>(jsonSerialization.deserializeList(java.util.UUID.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.util.UUID> borderValue3 = new java.util.HashSet<java.util.UUID>(java.util.Arrays.asList(java.util.UUID.randomUUID(), java.util.UUID.fromString("1-2-3-4-5"), new java.util.UUID(0L, 0L)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.util.UUID> borderValue3JsonDeserialized = new java.util.HashSet<java.util.UUID>(jsonSerialization.deserializeList(java.util.UUID.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertNullableSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Guid/OneArrayOfNullableGuidsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Guid/OneArrayOfNullableGuidsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Guid;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfNullableGuidsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.UUID[] defaultValue = new java.util.UUID[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.UUID[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.util.UUID[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.UUID[] borderValue1 = new java.util.UUID[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.UUID[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.util.UUID[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.UUID[] borderValue2 = new java.util.UUID[] { java.util.UUID.randomUUID() };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.UUID[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.util.UUID[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.UUID[] borderValue3 = new java.util.UUID[] { new java.util.UUID(0L, 0L) };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.UUID[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.util.UUID[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.UUID[] borderValue4 = new java.util.UUID[] { java.util.UUID.randomUUID(), java.util.UUID.fromString("1-2-3-4-5"), new java.util.UUID(0L, 0L) };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.UUID[] borderValue4JsonDeserialized = jsonSerialization.deserialize(java.util.UUID[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.UUID[] borderValue5 = new java.util.UUID[] { null, java.util.UUID.randomUUID(), java.util.UUID.fromString("1-2-3-4-5"), new java.util.UUID(0L, 0L) };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.UUID[] borderValue5JsonDeserialized = jsonSerialization.deserialize(java.util.UUID[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Guid/OneArrayOfOneGuidsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Guid/OneArrayOfOneGuidsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Guid;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfOneGuidsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.UUID[] defaultValue = new java.util.UUID[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.UUID[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.util.UUID[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.UUID[] borderValue1 = new java.util.UUID[] { java.util.UUID.randomUUID() };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.UUID[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.util.UUID[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.UUID[] borderValue2 = new java.util.UUID[] { new java.util.UUID(0L, 0L) };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.UUID[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.util.UUID[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.UUID[] borderValue3 = new java.util.UUID[] { java.util.UUID.randomUUID(), java.util.UUID.fromString("1-2-3-4-5"), new java.util.UUID(0L, 0L) };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.UUID[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.util.UUID[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Guid/OneGuidDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Guid/OneGuidDefaultValueTurtle.java
@@ -1,0 +1,46 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Guid;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneGuidDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.UUID defaultValue = java.util.UUID.randomUUID();
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.UUID defaultValueJsonDeserialized = jsonSerialization.deserialize(java.util.UUID.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.UUID borderValue1 = java.util.UUID.fromString("1-2-3-4-5");
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.UUID borderValue1JsonDeserialized = jsonSerialization.deserialize(java.util.UUID.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.UUID borderValue2 = new java.util.UUID(0L, 0L);
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.UUID borderValue2JsonDeserialized = jsonSerialization.deserialize(java.util.UUID.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Guid/OneListOfNullableGuidsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Guid/OneListOfNullableGuidsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Guid;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfNullableGuidsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.util.UUID> defaultValue = new java.util.ArrayList<java.util.UUID>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.util.UUID> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.util.UUID.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.util.UUID> borderValue1 = new java.util.ArrayList<java.util.UUID>(java.util.Arrays.asList((java.util.UUID) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.util.UUID> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.util.UUID.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.util.UUID> borderValue2 = new java.util.ArrayList<java.util.UUID>(java.util.Arrays.asList(java.util.UUID.randomUUID()));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.util.UUID> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.util.UUID.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.util.UUID> borderValue3 = new java.util.ArrayList<java.util.UUID>(java.util.Arrays.asList(new java.util.UUID(0L, 0L)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.util.UUID> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.util.UUID.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<java.util.UUID> borderValue4 = new java.util.ArrayList<java.util.UUID>(java.util.Arrays.asList(java.util.UUID.randomUUID(), java.util.UUID.fromString("1-2-3-4-5"), new java.util.UUID(0L, 0L)));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<java.util.UUID> borderValue4JsonDeserialized = jsonSerialization.deserializeList(java.util.UUID.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<java.util.UUID> borderValue5 = new java.util.ArrayList<java.util.UUID>(java.util.Arrays.asList((java.util.UUID) null, java.util.UUID.randomUUID(), java.util.UUID.fromString("1-2-3-4-5"), new java.util.UUID(0L, 0L)));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<java.util.UUID> borderValue5JsonDeserialized = jsonSerialization.deserializeList(java.util.UUID.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Guid/OneListOfOneGuidsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Guid/OneListOfOneGuidsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Guid;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfOneGuidsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.util.UUID> defaultValue = new java.util.ArrayList<java.util.UUID>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.util.UUID> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.util.UUID.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.util.UUID> borderValue1 = new java.util.ArrayList<java.util.UUID>(java.util.Arrays.asList(java.util.UUID.randomUUID()));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.util.UUID> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.util.UUID.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.util.UUID> borderValue2 = new java.util.ArrayList<java.util.UUID>(java.util.Arrays.asList(new java.util.UUID(0L, 0L)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.util.UUID> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.util.UUID.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.util.UUID> borderValue3 = new java.util.ArrayList<java.util.UUID>(java.util.Arrays.asList(java.util.UUID.randomUUID(), java.util.UUID.fromString("1-2-3-4-5"), new java.util.UUID(0L, 0L)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.util.UUID> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.util.UUID.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Guid/OneSetOfNullableGuidsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Guid/OneSetOfNullableGuidsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Guid;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfNullableGuidsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.util.UUID> defaultValue = new java.util.HashSet<java.util.UUID>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.util.UUID> defaultValueJsonDeserialized = new java.util.HashSet<java.util.UUID>(jsonSerialization.deserializeList(java.util.UUID.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.util.UUID> borderValue1 = new java.util.HashSet<java.util.UUID>(java.util.Arrays.asList((java.util.UUID) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.util.UUID> borderValue1JsonDeserialized = new java.util.HashSet<java.util.UUID>(jsonSerialization.deserializeList(java.util.UUID.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.util.UUID> borderValue2 = new java.util.HashSet<java.util.UUID>(java.util.Arrays.asList(java.util.UUID.randomUUID()));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.util.UUID> borderValue2JsonDeserialized = new java.util.HashSet<java.util.UUID>(jsonSerialization.deserializeList(java.util.UUID.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.util.UUID> borderValue3 = new java.util.HashSet<java.util.UUID>(java.util.Arrays.asList(new java.util.UUID(0L, 0L)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.util.UUID> borderValue3JsonDeserialized = new java.util.HashSet<java.util.UUID>(jsonSerialization.deserializeList(java.util.UUID.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<java.util.UUID> borderValue4 = new java.util.HashSet<java.util.UUID>(java.util.Arrays.asList(java.util.UUID.randomUUID(), java.util.UUID.fromString("1-2-3-4-5"), new java.util.UUID(0L, 0L)));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<java.util.UUID> borderValue4JsonDeserialized = new java.util.HashSet<java.util.UUID>(jsonSerialization.deserializeList(java.util.UUID.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<java.util.UUID> borderValue5 = new java.util.HashSet<java.util.UUID>(java.util.Arrays.asList((java.util.UUID) null, java.util.UUID.randomUUID(), java.util.UUID.fromString("1-2-3-4-5"), new java.util.UUID(0L, 0L)));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<java.util.UUID> borderValue5JsonDeserialized = new java.util.HashSet<java.util.UUID>(jsonSerialization.deserializeList(java.util.UUID.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Guid/OneSetOfOneGuidsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Guid/OneSetOfOneGuidsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Guid;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfOneGuidsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.util.UUID> defaultValue = new java.util.HashSet<java.util.UUID>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.util.UUID> defaultValueJsonDeserialized = new java.util.HashSet<java.util.UUID>(jsonSerialization.deserializeList(java.util.UUID.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.util.UUID> borderValue1 = new java.util.HashSet<java.util.UUID>(java.util.Arrays.asList(java.util.UUID.randomUUID()));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.util.UUID> borderValue1JsonDeserialized = new java.util.HashSet<java.util.UUID>(jsonSerialization.deserializeList(java.util.UUID.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.util.UUID> borderValue2 = new java.util.HashSet<java.util.UUID>(java.util.Arrays.asList(new java.util.UUID(0L, 0L)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.util.UUID> borderValue2JsonDeserialized = new java.util.HashSet<java.util.UUID>(jsonSerialization.deserializeList(java.util.UUID.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.util.UUID> borderValue3 = new java.util.HashSet<java.util.UUID>(java.util.Arrays.asList(java.util.UUID.randomUUID(), java.util.UUID.fromString("1-2-3-4-5"), new java.util.UUID(0L, 0L)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.util.UUID> borderValue3JsonDeserialized = new java.util.HashSet<java.util.UUID>(jsonSerialization.deserializeList(java.util.UUID.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.GuidAsserts.assertOneSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Image/NullableArrayOfNullableImagesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Image/NullableArrayOfNullableImagesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Image;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfNullableImagesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.awt.image.BufferedImage[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.awt.image.BufferedImage[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.awt.image.BufferedImage[] borderValue1 = new java.awt.image.BufferedImage[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.awt.image.BufferedImage[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.awt.image.BufferedImage[] borderValue2 = new java.awt.image.BufferedImage[] { new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR) };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.awt.image.BufferedImage[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.awt.image.BufferedImage[] borderValue3 = new java.awt.image.BufferedImage[] { new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB) };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.awt.image.BufferedImage[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.awt.image.BufferedImage[] borderValue4 = new java.awt.image.BufferedImage[] { new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR), new java.awt.image.BufferedImage(2, 2, java.awt.image.BufferedImage.TYPE_3BYTE_BGR), new java.awt.image.BufferedImage(3, 3, java.awt.image.BufferedImage.TYPE_BYTE_BINARY), new java.awt.image.BufferedImage(4, 4, java.awt.image.BufferedImage.TYPE_BYTE_GRAY), new java.awt.image.BufferedImage(5, 5, java.awt.image.BufferedImage.TYPE_BYTE_INDEXED), new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB) };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.awt.image.BufferedImage[] borderValue4JsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.awt.image.BufferedImage[] borderValue5 = new java.awt.image.BufferedImage[] { null, new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR), new java.awt.image.BufferedImage(2, 2, java.awt.image.BufferedImage.TYPE_3BYTE_BGR), new java.awt.image.BufferedImage(3, 3, java.awt.image.BufferedImage.TYPE_BYTE_BINARY), new java.awt.image.BufferedImage(4, 4, java.awt.image.BufferedImage.TYPE_BYTE_GRAY), new java.awt.image.BufferedImage(5, 5, java.awt.image.BufferedImage.TYPE_BYTE_INDEXED), new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB) };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.awt.image.BufferedImage[] borderValue5JsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Image/NullableArrayOfOneImagesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Image/NullableArrayOfOneImagesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Image;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfOneImagesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.awt.image.BufferedImage[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.awt.image.BufferedImage[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.awt.image.BufferedImage[] borderValue1 = new java.awt.image.BufferedImage[] { new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR) };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.awt.image.BufferedImage[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.awt.image.BufferedImage[] borderValue2 = new java.awt.image.BufferedImage[] { new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB) };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.awt.image.BufferedImage[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.awt.image.BufferedImage[] borderValue3 = new java.awt.image.BufferedImage[] { new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR), new java.awt.image.BufferedImage(2, 2, java.awt.image.BufferedImage.TYPE_3BYTE_BGR), new java.awt.image.BufferedImage(3, 3, java.awt.image.BufferedImage.TYPE_BYTE_BINARY), new java.awt.image.BufferedImage(4, 4, java.awt.image.BufferedImage.TYPE_BYTE_GRAY), new java.awt.image.BufferedImage(5, 5, java.awt.image.BufferedImage.TYPE_BYTE_INDEXED), new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB) };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.awt.image.BufferedImage[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Image/NullableImageDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Image/NullableImageDefaultValueTurtle.java
@@ -1,0 +1,82 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Image;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableImageDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.awt.image.BufferedImage defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.awt.image.BufferedImage defaultValueJsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.awt.image.BufferedImage borderValue1 = new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR);
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.awt.image.BufferedImage borderValue1JsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.awt.image.BufferedImage borderValue2 = new java.awt.image.BufferedImage(2, 2, java.awt.image.BufferedImage.TYPE_3BYTE_BGR);
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.awt.image.BufferedImage borderValue2JsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.awt.image.BufferedImage borderValue3 = new java.awt.image.BufferedImage(3, 3, java.awt.image.BufferedImage.TYPE_BYTE_BINARY);
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.awt.image.BufferedImage borderValue3JsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.awt.image.BufferedImage borderValue4 = new java.awt.image.BufferedImage(4, 4, java.awt.image.BufferedImage.TYPE_BYTE_GRAY);
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.awt.image.BufferedImage borderValue4JsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.awt.image.BufferedImage borderValue5 = new java.awt.image.BufferedImage(5, 5, java.awt.image.BufferedImage.TYPE_BYTE_INDEXED);
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.awt.image.BufferedImage borderValue5JsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue6Equality() throws IOException {
+        final java.awt.image.BufferedImage borderValue6 = new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB);
+        final Bytes borderValue6JsonSerialized = jsonSerialization.serialize(borderValue6);
+        final java.awt.image.BufferedImage borderValue6JsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage.class, borderValue6JsonSerialized.content, borderValue6JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableEquals(borderValue6, borderValue6JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Image/NullableListOfNullableImagesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Image/NullableListOfNullableImagesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Image;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfNullableImagesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.awt.image.BufferedImage> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.awt.image.BufferedImage> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.awt.image.BufferedImage> borderValue1 = new java.util.ArrayList<java.awt.image.BufferedImage>(java.util.Arrays.asList((java.awt.image.BufferedImage) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.awt.image.BufferedImage> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.awt.image.BufferedImage> borderValue2 = new java.util.ArrayList<java.awt.image.BufferedImage>(java.util.Arrays.asList(new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.awt.image.BufferedImage> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.awt.image.BufferedImage> borderValue3 = new java.util.ArrayList<java.awt.image.BufferedImage>(java.util.Arrays.asList(new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.awt.image.BufferedImage> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<java.awt.image.BufferedImage> borderValue4 = new java.util.ArrayList<java.awt.image.BufferedImage>(java.util.Arrays.asList(new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR), new java.awt.image.BufferedImage(2, 2, java.awt.image.BufferedImage.TYPE_3BYTE_BGR), new java.awt.image.BufferedImage(3, 3, java.awt.image.BufferedImage.TYPE_BYTE_BINARY), new java.awt.image.BufferedImage(4, 4, java.awt.image.BufferedImage.TYPE_BYTE_GRAY), new java.awt.image.BufferedImage(5, 5, java.awt.image.BufferedImage.TYPE_BYTE_INDEXED), new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB)));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<java.awt.image.BufferedImage> borderValue4JsonDeserialized = jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<java.awt.image.BufferedImage> borderValue5 = new java.util.ArrayList<java.awt.image.BufferedImage>(java.util.Arrays.asList((java.awt.image.BufferedImage) null, new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR), new java.awt.image.BufferedImage(2, 2, java.awt.image.BufferedImage.TYPE_3BYTE_BGR), new java.awt.image.BufferedImage(3, 3, java.awt.image.BufferedImage.TYPE_BYTE_BINARY), new java.awt.image.BufferedImage(4, 4, java.awt.image.BufferedImage.TYPE_BYTE_GRAY), new java.awt.image.BufferedImage(5, 5, java.awt.image.BufferedImage.TYPE_BYTE_INDEXED), new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB)));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<java.awt.image.BufferedImage> borderValue5JsonDeserialized = jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Image/NullableListOfOneImagesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Image/NullableListOfOneImagesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Image;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfOneImagesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.awt.image.BufferedImage> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.awt.image.BufferedImage> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.awt.image.BufferedImage> borderValue1 = new java.util.ArrayList<java.awt.image.BufferedImage>(java.util.Arrays.asList(new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR)));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.awt.image.BufferedImage> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.awt.image.BufferedImage> borderValue2 = new java.util.ArrayList<java.awt.image.BufferedImage>(java.util.Arrays.asList(new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.awt.image.BufferedImage> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.awt.image.BufferedImage> borderValue3 = new java.util.ArrayList<java.awt.image.BufferedImage>(java.util.Arrays.asList(new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR), new java.awt.image.BufferedImage(2, 2, java.awt.image.BufferedImage.TYPE_3BYTE_BGR), new java.awt.image.BufferedImage(3, 3, java.awt.image.BufferedImage.TYPE_BYTE_BINARY), new java.awt.image.BufferedImage(4, 4, java.awt.image.BufferedImage.TYPE_BYTE_GRAY), new java.awt.image.BufferedImage(5, 5, java.awt.image.BufferedImage.TYPE_BYTE_INDEXED), new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.awt.image.BufferedImage> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Image/NullableSetOfNullableImagesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Image/NullableSetOfNullableImagesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Image;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfNullableImagesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.awt.image.BufferedImage> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.awt.image.BufferedImage> defaultValueJsonDeserialized = new java.util.HashSet<java.awt.image.BufferedImage>(jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.awt.image.BufferedImage> borderValue1 = new java.util.HashSet<java.awt.image.BufferedImage>(java.util.Arrays.asList((java.awt.image.BufferedImage) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.awt.image.BufferedImage> borderValue1JsonDeserialized = new java.util.HashSet<java.awt.image.BufferedImage>(jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.awt.image.BufferedImage> borderValue2 = new java.util.HashSet<java.awt.image.BufferedImage>(java.util.Arrays.asList(new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.awt.image.BufferedImage> borderValue2JsonDeserialized = new java.util.HashSet<java.awt.image.BufferedImage>(jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.awt.image.BufferedImage> borderValue3 = new java.util.HashSet<java.awt.image.BufferedImage>(java.util.Arrays.asList(new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.awt.image.BufferedImage> borderValue3JsonDeserialized = new java.util.HashSet<java.awt.image.BufferedImage>(jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<java.awt.image.BufferedImage> borderValue4 = new java.util.HashSet<java.awt.image.BufferedImage>(java.util.Arrays.asList(new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR), new java.awt.image.BufferedImage(2, 2, java.awt.image.BufferedImage.TYPE_3BYTE_BGR), new java.awt.image.BufferedImage(3, 3, java.awt.image.BufferedImage.TYPE_BYTE_BINARY), new java.awt.image.BufferedImage(4, 4, java.awt.image.BufferedImage.TYPE_BYTE_GRAY), new java.awt.image.BufferedImage(5, 5, java.awt.image.BufferedImage.TYPE_BYTE_INDEXED), new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB)));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<java.awt.image.BufferedImage> borderValue4JsonDeserialized = new java.util.HashSet<java.awt.image.BufferedImage>(jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<java.awt.image.BufferedImage> borderValue5 = new java.util.HashSet<java.awt.image.BufferedImage>(java.util.Arrays.asList((java.awt.image.BufferedImage) null, new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR), new java.awt.image.BufferedImage(2, 2, java.awt.image.BufferedImage.TYPE_3BYTE_BGR), new java.awt.image.BufferedImage(3, 3, java.awt.image.BufferedImage.TYPE_BYTE_BINARY), new java.awt.image.BufferedImage(4, 4, java.awt.image.BufferedImage.TYPE_BYTE_GRAY), new java.awt.image.BufferedImage(5, 5, java.awt.image.BufferedImage.TYPE_BYTE_INDEXED), new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB)));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<java.awt.image.BufferedImage> borderValue5JsonDeserialized = new java.util.HashSet<java.awt.image.BufferedImage>(jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Image/NullableSetOfOneImagesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Image/NullableSetOfOneImagesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Image;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfOneImagesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.awt.image.BufferedImage> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.awt.image.BufferedImage> defaultValueJsonDeserialized = new java.util.HashSet<java.awt.image.BufferedImage>(jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.awt.image.BufferedImage> borderValue1 = new java.util.HashSet<java.awt.image.BufferedImage>(java.util.Arrays.asList(new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR)));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.awt.image.BufferedImage> borderValue1JsonDeserialized = new java.util.HashSet<java.awt.image.BufferedImage>(jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.awt.image.BufferedImage> borderValue2 = new java.util.HashSet<java.awt.image.BufferedImage>(java.util.Arrays.asList(new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.awt.image.BufferedImage> borderValue2JsonDeserialized = new java.util.HashSet<java.awt.image.BufferedImage>(jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.awt.image.BufferedImage> borderValue3 = new java.util.HashSet<java.awt.image.BufferedImage>(java.util.Arrays.asList(new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR), new java.awt.image.BufferedImage(2, 2, java.awt.image.BufferedImage.TYPE_3BYTE_BGR), new java.awt.image.BufferedImage(3, 3, java.awt.image.BufferedImage.TYPE_BYTE_BINARY), new java.awt.image.BufferedImage(4, 4, java.awt.image.BufferedImage.TYPE_BYTE_GRAY), new java.awt.image.BufferedImage(5, 5, java.awt.image.BufferedImage.TYPE_BYTE_INDEXED), new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.awt.image.BufferedImage> borderValue3JsonDeserialized = new java.util.HashSet<java.awt.image.BufferedImage>(jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertNullableSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Image/OneArrayOfNullableImagesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Image/OneArrayOfNullableImagesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Image;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfNullableImagesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.awt.image.BufferedImage[] defaultValue = new java.awt.image.BufferedImage[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.awt.image.BufferedImage[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.awt.image.BufferedImage[] borderValue1 = new java.awt.image.BufferedImage[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.awt.image.BufferedImage[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.awt.image.BufferedImage[] borderValue2 = new java.awt.image.BufferedImage[] { new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR) };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.awt.image.BufferedImage[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.awt.image.BufferedImage[] borderValue3 = new java.awt.image.BufferedImage[] { new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB) };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.awt.image.BufferedImage[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.awt.image.BufferedImage[] borderValue4 = new java.awt.image.BufferedImage[] { new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR), new java.awt.image.BufferedImage(2, 2, java.awt.image.BufferedImage.TYPE_3BYTE_BGR), new java.awt.image.BufferedImage(3, 3, java.awt.image.BufferedImage.TYPE_BYTE_BINARY), new java.awt.image.BufferedImage(4, 4, java.awt.image.BufferedImage.TYPE_BYTE_GRAY), new java.awt.image.BufferedImage(5, 5, java.awt.image.BufferedImage.TYPE_BYTE_INDEXED), new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB) };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.awt.image.BufferedImage[] borderValue4JsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.awt.image.BufferedImage[] borderValue5 = new java.awt.image.BufferedImage[] { null, new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR), new java.awt.image.BufferedImage(2, 2, java.awt.image.BufferedImage.TYPE_3BYTE_BGR), new java.awt.image.BufferedImage(3, 3, java.awt.image.BufferedImage.TYPE_BYTE_BINARY), new java.awt.image.BufferedImage(4, 4, java.awt.image.BufferedImage.TYPE_BYTE_GRAY), new java.awt.image.BufferedImage(5, 5, java.awt.image.BufferedImage.TYPE_BYTE_INDEXED), new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB) };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.awt.image.BufferedImage[] borderValue5JsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Image/OneArrayOfOneImagesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Image/OneArrayOfOneImagesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Image;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfOneImagesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.awt.image.BufferedImage[] defaultValue = new java.awt.image.BufferedImage[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.awt.image.BufferedImage[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.awt.image.BufferedImage[] borderValue1 = new java.awt.image.BufferedImage[] { new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR) };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.awt.image.BufferedImage[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.awt.image.BufferedImage[] borderValue2 = new java.awt.image.BufferedImage[] { new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB) };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.awt.image.BufferedImage[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.awt.image.BufferedImage[] borderValue3 = new java.awt.image.BufferedImage[] { new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR), new java.awt.image.BufferedImage(2, 2, java.awt.image.BufferedImage.TYPE_3BYTE_BGR), new java.awt.image.BufferedImage(3, 3, java.awt.image.BufferedImage.TYPE_BYTE_BINARY), new java.awt.image.BufferedImage(4, 4, java.awt.image.BufferedImage.TYPE_BYTE_GRAY), new java.awt.image.BufferedImage(5, 5, java.awt.image.BufferedImage.TYPE_BYTE_INDEXED), new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB) };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.awt.image.BufferedImage[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Image/OneImageDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Image/OneImageDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Image;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneImageDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.awt.image.BufferedImage defaultValue = new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.awt.image.BufferedImage defaultValueJsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.awt.image.BufferedImage borderValue1 = new java.awt.image.BufferedImage(2, 2, java.awt.image.BufferedImage.TYPE_3BYTE_BGR);
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.awt.image.BufferedImage borderValue1JsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.awt.image.BufferedImage borderValue2 = new java.awt.image.BufferedImage(3, 3, java.awt.image.BufferedImage.TYPE_BYTE_BINARY);
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.awt.image.BufferedImage borderValue2JsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.awt.image.BufferedImage borderValue3 = new java.awt.image.BufferedImage(4, 4, java.awt.image.BufferedImage.TYPE_BYTE_GRAY);
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.awt.image.BufferedImage borderValue3JsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.awt.image.BufferedImage borderValue4 = new java.awt.image.BufferedImage(5, 5, java.awt.image.BufferedImage.TYPE_BYTE_INDEXED);
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.awt.image.BufferedImage borderValue4JsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.awt.image.BufferedImage borderValue5 = new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB);
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.awt.image.BufferedImage borderValue5JsonDeserialized = jsonSerialization.deserialize(java.awt.image.BufferedImage.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Image/OneListOfNullableImagesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Image/OneListOfNullableImagesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Image;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfNullableImagesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.awt.image.BufferedImage> defaultValue = new java.util.ArrayList<java.awt.image.BufferedImage>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.awt.image.BufferedImage> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.awt.image.BufferedImage> borderValue1 = new java.util.ArrayList<java.awt.image.BufferedImage>(java.util.Arrays.asList((java.awt.image.BufferedImage) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.awt.image.BufferedImage> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.awt.image.BufferedImage> borderValue2 = new java.util.ArrayList<java.awt.image.BufferedImage>(java.util.Arrays.asList(new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.awt.image.BufferedImage> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.awt.image.BufferedImage> borderValue3 = new java.util.ArrayList<java.awt.image.BufferedImage>(java.util.Arrays.asList(new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.awt.image.BufferedImage> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<java.awt.image.BufferedImage> borderValue4 = new java.util.ArrayList<java.awt.image.BufferedImage>(java.util.Arrays.asList(new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR), new java.awt.image.BufferedImage(2, 2, java.awt.image.BufferedImage.TYPE_3BYTE_BGR), new java.awt.image.BufferedImage(3, 3, java.awt.image.BufferedImage.TYPE_BYTE_BINARY), new java.awt.image.BufferedImage(4, 4, java.awt.image.BufferedImage.TYPE_BYTE_GRAY), new java.awt.image.BufferedImage(5, 5, java.awt.image.BufferedImage.TYPE_BYTE_INDEXED), new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB)));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<java.awt.image.BufferedImage> borderValue4JsonDeserialized = jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<java.awt.image.BufferedImage> borderValue5 = new java.util.ArrayList<java.awt.image.BufferedImage>(java.util.Arrays.asList((java.awt.image.BufferedImage) null, new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR), new java.awt.image.BufferedImage(2, 2, java.awt.image.BufferedImage.TYPE_3BYTE_BGR), new java.awt.image.BufferedImage(3, 3, java.awt.image.BufferedImage.TYPE_BYTE_BINARY), new java.awt.image.BufferedImage(4, 4, java.awt.image.BufferedImage.TYPE_BYTE_GRAY), new java.awt.image.BufferedImage(5, 5, java.awt.image.BufferedImage.TYPE_BYTE_INDEXED), new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB)));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<java.awt.image.BufferedImage> borderValue5JsonDeserialized = jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Image/OneListOfOneImagesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Image/OneListOfOneImagesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Image;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfOneImagesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.awt.image.BufferedImage> defaultValue = new java.util.ArrayList<java.awt.image.BufferedImage>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.awt.image.BufferedImage> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.awt.image.BufferedImage> borderValue1 = new java.util.ArrayList<java.awt.image.BufferedImage>(java.util.Arrays.asList(new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR)));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.awt.image.BufferedImage> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.awt.image.BufferedImage> borderValue2 = new java.util.ArrayList<java.awt.image.BufferedImage>(java.util.Arrays.asList(new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.awt.image.BufferedImage> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.awt.image.BufferedImage> borderValue3 = new java.util.ArrayList<java.awt.image.BufferedImage>(java.util.Arrays.asList(new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR), new java.awt.image.BufferedImage(2, 2, java.awt.image.BufferedImage.TYPE_3BYTE_BGR), new java.awt.image.BufferedImage(3, 3, java.awt.image.BufferedImage.TYPE_BYTE_BINARY), new java.awt.image.BufferedImage(4, 4, java.awt.image.BufferedImage.TYPE_BYTE_GRAY), new java.awt.image.BufferedImage(5, 5, java.awt.image.BufferedImage.TYPE_BYTE_INDEXED), new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.awt.image.BufferedImage> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Image/OneSetOfNullableImagesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Image/OneSetOfNullableImagesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Image;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfNullableImagesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.awt.image.BufferedImage> defaultValue = new java.util.HashSet<java.awt.image.BufferedImage>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.awt.image.BufferedImage> defaultValueJsonDeserialized = new java.util.HashSet<java.awt.image.BufferedImage>(jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.awt.image.BufferedImage> borderValue1 = new java.util.HashSet<java.awt.image.BufferedImage>(java.util.Arrays.asList((java.awt.image.BufferedImage) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.awt.image.BufferedImage> borderValue1JsonDeserialized = new java.util.HashSet<java.awt.image.BufferedImage>(jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.awt.image.BufferedImage> borderValue2 = new java.util.HashSet<java.awt.image.BufferedImage>(java.util.Arrays.asList(new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.awt.image.BufferedImage> borderValue2JsonDeserialized = new java.util.HashSet<java.awt.image.BufferedImage>(jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.awt.image.BufferedImage> borderValue3 = new java.util.HashSet<java.awt.image.BufferedImage>(java.util.Arrays.asList(new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.awt.image.BufferedImage> borderValue3JsonDeserialized = new java.util.HashSet<java.awt.image.BufferedImage>(jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<java.awt.image.BufferedImage> borderValue4 = new java.util.HashSet<java.awt.image.BufferedImage>(java.util.Arrays.asList(new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR), new java.awt.image.BufferedImage(2, 2, java.awt.image.BufferedImage.TYPE_3BYTE_BGR), new java.awt.image.BufferedImage(3, 3, java.awt.image.BufferedImage.TYPE_BYTE_BINARY), new java.awt.image.BufferedImage(4, 4, java.awt.image.BufferedImage.TYPE_BYTE_GRAY), new java.awt.image.BufferedImage(5, 5, java.awt.image.BufferedImage.TYPE_BYTE_INDEXED), new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB)));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<java.awt.image.BufferedImage> borderValue4JsonDeserialized = new java.util.HashSet<java.awt.image.BufferedImage>(jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<java.awt.image.BufferedImage> borderValue5 = new java.util.HashSet<java.awt.image.BufferedImage>(java.util.Arrays.asList((java.awt.image.BufferedImage) null, new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR), new java.awt.image.BufferedImage(2, 2, java.awt.image.BufferedImage.TYPE_3BYTE_BGR), new java.awt.image.BufferedImage(3, 3, java.awt.image.BufferedImage.TYPE_BYTE_BINARY), new java.awt.image.BufferedImage(4, 4, java.awt.image.BufferedImage.TYPE_BYTE_GRAY), new java.awt.image.BufferedImage(5, 5, java.awt.image.BufferedImage.TYPE_BYTE_INDEXED), new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB)));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<java.awt.image.BufferedImage> borderValue5JsonDeserialized = new java.util.HashSet<java.awt.image.BufferedImage>(jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Image/OneSetOfOneImagesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Image/OneSetOfOneImagesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Image;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfOneImagesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.awt.image.BufferedImage> defaultValue = new java.util.HashSet<java.awt.image.BufferedImage>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.awt.image.BufferedImage> defaultValueJsonDeserialized = new java.util.HashSet<java.awt.image.BufferedImage>(jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.awt.image.BufferedImage> borderValue1 = new java.util.HashSet<java.awt.image.BufferedImage>(java.util.Arrays.asList(new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR)));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.awt.image.BufferedImage> borderValue1JsonDeserialized = new java.util.HashSet<java.awt.image.BufferedImage>(jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.awt.image.BufferedImage> borderValue2 = new java.util.HashSet<java.awt.image.BufferedImage>(java.util.Arrays.asList(new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.awt.image.BufferedImage> borderValue2JsonDeserialized = new java.util.HashSet<java.awt.image.BufferedImage>(jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.awt.image.BufferedImage> borderValue3 = new java.util.HashSet<java.awt.image.BufferedImage>(java.util.Arrays.asList(new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_4BYTE_ABGR), new java.awt.image.BufferedImage(2, 2, java.awt.image.BufferedImage.TYPE_3BYTE_BGR), new java.awt.image.BufferedImage(3, 3, java.awt.image.BufferedImage.TYPE_BYTE_BINARY), new java.awt.image.BufferedImage(4, 4, java.awt.image.BufferedImage.TYPE_BYTE_GRAY), new java.awt.image.BufferedImage(5, 5, java.awt.image.BufferedImage.TYPE_BYTE_INDEXED), new java.awt.image.BufferedImage(6, 6, java.awt.image.BufferedImage.TYPE_INT_RGB)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.awt.image.BufferedImage> borderValue3JsonDeserialized = new java.util.HashSet<java.awt.image.BufferedImage>(jsonSerialization.deserializeList(java.awt.image.BufferedImage.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.ImageAsserts.assertOneSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Integer/NullableArrayOfNullableIntegersDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Integer/NullableArrayOfNullableIntegersDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Integer;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfNullableIntegersDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final Integer[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final Integer[] defaultValueJsonDeserialized = jsonSerialization.deserialize(Integer[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final Integer[] borderValue1 = new Integer[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final Integer[] borderValue1JsonDeserialized = jsonSerialization.deserialize(Integer[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final Integer[] borderValue2 = new Integer[] { 0 };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final Integer[] borderValue2JsonDeserialized = jsonSerialization.deserialize(Integer[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final Integer[] borderValue3 = new Integer[] { 1000000000 };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final Integer[] borderValue3JsonDeserialized = jsonSerialization.deserialize(Integer[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final Integer[] borderValue4 = new Integer[] { 0, Integer.MIN_VALUE, Integer.MAX_VALUE, -1000000000, 1000000000 };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final Integer[] borderValue4JsonDeserialized = jsonSerialization.deserialize(Integer[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final Integer[] borderValue5 = new Integer[] { null, 0, Integer.MIN_VALUE, Integer.MAX_VALUE, -1000000000, 1000000000 };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final Integer[] borderValue5JsonDeserialized = jsonSerialization.deserialize(Integer[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Integer/NullableArrayOfOneIntegersDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Integer/NullableArrayOfOneIntegersDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Integer;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfOneIntegersDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final int[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final int[] defaultValueJsonDeserialized = jsonSerialization.deserialize(int[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final int[] borderValue1 = new int[] { 0 };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final int[] borderValue1JsonDeserialized = jsonSerialization.deserialize(int[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final int[] borderValue2 = new int[] { 1000000000 };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final int[] borderValue2JsonDeserialized = jsonSerialization.deserialize(int[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final int[] borderValue3 = new int[] { 0, Integer.MIN_VALUE, Integer.MAX_VALUE, -1000000000, 1000000000 };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final int[] borderValue3JsonDeserialized = jsonSerialization.deserialize(int[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Integer/NullableIntegerDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Integer/NullableIntegerDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Integer;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableIntegerDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final Integer defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final Integer defaultValueJsonDeserialized = jsonSerialization.deserialize(Integer.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final Integer borderValue1 = 0;
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final Integer borderValue1JsonDeserialized = jsonSerialization.deserialize(Integer.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final Integer borderValue2 = Integer.MIN_VALUE;
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final Integer borderValue2JsonDeserialized = jsonSerialization.deserialize(Integer.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final Integer borderValue3 = Integer.MAX_VALUE;
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final Integer borderValue3JsonDeserialized = jsonSerialization.deserialize(Integer.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final Integer borderValue4 = -1000000000;
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final Integer borderValue4JsonDeserialized = jsonSerialization.deserialize(Integer.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final Integer borderValue5 = 1000000000;
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final Integer borderValue5JsonDeserialized = jsonSerialization.deserialize(Integer.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Integer/NullableListOfNullableIntegersDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Integer/NullableListOfNullableIntegersDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Integer;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfNullableIntegersDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<Integer> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<Integer> defaultValueJsonDeserialized = jsonSerialization.deserializeList(Integer.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<Integer> borderValue1 = new java.util.ArrayList<Integer>(java.util.Arrays.asList((Integer) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<Integer> borderValue1JsonDeserialized = jsonSerialization.deserializeList(Integer.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<Integer> borderValue2 = new java.util.ArrayList<Integer>(java.util.Arrays.asList(0));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<Integer> borderValue2JsonDeserialized = jsonSerialization.deserializeList(Integer.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<Integer> borderValue3 = new java.util.ArrayList<Integer>(java.util.Arrays.asList(1000000000));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<Integer> borderValue3JsonDeserialized = jsonSerialization.deserializeList(Integer.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<Integer> borderValue4 = new java.util.ArrayList<Integer>(java.util.Arrays.asList(0, Integer.MIN_VALUE, Integer.MAX_VALUE, -1000000000, 1000000000));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<Integer> borderValue4JsonDeserialized = jsonSerialization.deserializeList(Integer.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<Integer> borderValue5 = new java.util.ArrayList<Integer>(java.util.Arrays.asList((Integer) null, 0, Integer.MIN_VALUE, Integer.MAX_VALUE, -1000000000, 1000000000));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<Integer> borderValue5JsonDeserialized = jsonSerialization.deserializeList(Integer.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Integer/NullableListOfOneIntegersDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Integer/NullableListOfOneIntegersDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Integer;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfOneIntegersDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<Integer> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<Integer> defaultValueJsonDeserialized = jsonSerialization.deserializeList(Integer.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<Integer> borderValue1 = new java.util.ArrayList<Integer>(java.util.Arrays.asList(0));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<Integer> borderValue1JsonDeserialized = jsonSerialization.deserializeList(Integer.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<Integer> borderValue2 = new java.util.ArrayList<Integer>(java.util.Arrays.asList(1000000000));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<Integer> borderValue2JsonDeserialized = jsonSerialization.deserializeList(Integer.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<Integer> borderValue3 = new java.util.ArrayList<Integer>(java.util.Arrays.asList(0, Integer.MIN_VALUE, Integer.MAX_VALUE, -1000000000, 1000000000));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<Integer> borderValue3JsonDeserialized = jsonSerialization.deserializeList(Integer.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Integer/NullableSetOfNullableIntegersDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Integer/NullableSetOfNullableIntegersDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Integer;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfNullableIntegersDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<Integer> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<Integer> defaultValueJsonDeserialized = new java.util.HashSet<Integer>(jsonSerialization.deserializeList(Integer.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<Integer> borderValue1 = new java.util.HashSet<Integer>(java.util.Arrays.asList((Integer) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<Integer> borderValue1JsonDeserialized = new java.util.HashSet<Integer>(jsonSerialization.deserializeList(Integer.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<Integer> borderValue2 = new java.util.HashSet<Integer>(java.util.Arrays.asList(0));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<Integer> borderValue2JsonDeserialized = new java.util.HashSet<Integer>(jsonSerialization.deserializeList(Integer.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<Integer> borderValue3 = new java.util.HashSet<Integer>(java.util.Arrays.asList(1000000000));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<Integer> borderValue3JsonDeserialized = new java.util.HashSet<Integer>(jsonSerialization.deserializeList(Integer.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<Integer> borderValue4 = new java.util.HashSet<Integer>(java.util.Arrays.asList(0, Integer.MIN_VALUE, Integer.MAX_VALUE, -1000000000, 1000000000));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<Integer> borderValue4JsonDeserialized = new java.util.HashSet<Integer>(jsonSerialization.deserializeList(Integer.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<Integer> borderValue5 = new java.util.HashSet<Integer>(java.util.Arrays.asList((Integer) null, 0, Integer.MIN_VALUE, Integer.MAX_VALUE, -1000000000, 1000000000));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<Integer> borderValue5JsonDeserialized = new java.util.HashSet<Integer>(jsonSerialization.deserializeList(Integer.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Integer/NullableSetOfOneIntegersDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Integer/NullableSetOfOneIntegersDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Integer;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfOneIntegersDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<Integer> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<Integer> defaultValueJsonDeserialized = new java.util.HashSet<Integer>(jsonSerialization.deserializeList(Integer.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<Integer> borderValue1 = new java.util.HashSet<Integer>(java.util.Arrays.asList(0));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<Integer> borderValue1JsonDeserialized = new java.util.HashSet<Integer>(jsonSerialization.deserializeList(Integer.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<Integer> borderValue2 = new java.util.HashSet<Integer>(java.util.Arrays.asList(1000000000));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<Integer> borderValue2JsonDeserialized = new java.util.HashSet<Integer>(jsonSerialization.deserializeList(Integer.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<Integer> borderValue3 = new java.util.HashSet<Integer>(java.util.Arrays.asList(0, Integer.MIN_VALUE, Integer.MAX_VALUE, -1000000000, 1000000000));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<Integer> borderValue3JsonDeserialized = new java.util.HashSet<Integer>(jsonSerialization.deserializeList(Integer.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertNullableSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Integer/OneArrayOfNullableIntegersDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Integer/OneArrayOfNullableIntegersDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Integer;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfNullableIntegersDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final Integer[] defaultValue = new Integer[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final Integer[] defaultValueJsonDeserialized = jsonSerialization.deserialize(Integer[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final Integer[] borderValue1 = new Integer[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final Integer[] borderValue1JsonDeserialized = jsonSerialization.deserialize(Integer[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final Integer[] borderValue2 = new Integer[] { 0 };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final Integer[] borderValue2JsonDeserialized = jsonSerialization.deserialize(Integer[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final Integer[] borderValue3 = new Integer[] { 1000000000 };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final Integer[] borderValue3JsonDeserialized = jsonSerialization.deserialize(Integer[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final Integer[] borderValue4 = new Integer[] { 0, Integer.MIN_VALUE, Integer.MAX_VALUE, -1000000000, 1000000000 };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final Integer[] borderValue4JsonDeserialized = jsonSerialization.deserialize(Integer[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final Integer[] borderValue5 = new Integer[] { null, 0, Integer.MIN_VALUE, Integer.MAX_VALUE, -1000000000, 1000000000 };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final Integer[] borderValue5JsonDeserialized = jsonSerialization.deserialize(Integer[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Integer/OneArrayOfOneIntegersDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Integer/OneArrayOfOneIntegersDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Integer;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfOneIntegersDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final int[] defaultValue = new int[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final int[] defaultValueJsonDeserialized = jsonSerialization.deserialize(int[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final int[] borderValue1 = new int[] { 0 };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final int[] borderValue1JsonDeserialized = jsonSerialization.deserialize(int[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final int[] borderValue2 = new int[] { 1000000000 };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final int[] borderValue2JsonDeserialized = jsonSerialization.deserialize(int[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final int[] borderValue3 = new int[] { 0, Integer.MIN_VALUE, Integer.MAX_VALUE, -1000000000, 1000000000 };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final int[] borderValue3JsonDeserialized = jsonSerialization.deserialize(int[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Integer/OneIntegerDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Integer/OneIntegerDefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Integer;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneIntegerDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final int defaultValue = 0;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final int defaultValueJsonDeserialized = jsonSerialization.deserialize(int.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final int borderValue1 = Integer.MIN_VALUE;
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final int borderValue1JsonDeserialized = jsonSerialization.deserialize(int.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final int borderValue2 = Integer.MAX_VALUE;
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final int borderValue2JsonDeserialized = jsonSerialization.deserialize(int.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final int borderValue3 = -1000000000;
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final int borderValue3JsonDeserialized = jsonSerialization.deserialize(int.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final int borderValue4 = 1000000000;
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final int borderValue4JsonDeserialized = jsonSerialization.deserialize(int.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Integer/OneListOfNullableIntegersDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Integer/OneListOfNullableIntegersDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Integer;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfNullableIntegersDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<Integer> defaultValue = new java.util.ArrayList<Integer>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<Integer> defaultValueJsonDeserialized = jsonSerialization.deserializeList(Integer.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<Integer> borderValue1 = new java.util.ArrayList<Integer>(java.util.Arrays.asList((Integer) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<Integer> borderValue1JsonDeserialized = jsonSerialization.deserializeList(Integer.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<Integer> borderValue2 = new java.util.ArrayList<Integer>(java.util.Arrays.asList(0));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<Integer> borderValue2JsonDeserialized = jsonSerialization.deserializeList(Integer.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<Integer> borderValue3 = new java.util.ArrayList<Integer>(java.util.Arrays.asList(1000000000));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<Integer> borderValue3JsonDeserialized = jsonSerialization.deserializeList(Integer.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<Integer> borderValue4 = new java.util.ArrayList<Integer>(java.util.Arrays.asList(0, Integer.MIN_VALUE, Integer.MAX_VALUE, -1000000000, 1000000000));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<Integer> borderValue4JsonDeserialized = jsonSerialization.deserializeList(Integer.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<Integer> borderValue5 = new java.util.ArrayList<Integer>(java.util.Arrays.asList((Integer) null, 0, Integer.MIN_VALUE, Integer.MAX_VALUE, -1000000000, 1000000000));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<Integer> borderValue5JsonDeserialized = jsonSerialization.deserializeList(Integer.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Integer/OneListOfOneIntegersDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Integer/OneListOfOneIntegersDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Integer;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfOneIntegersDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<Integer> defaultValue = new java.util.ArrayList<Integer>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<Integer> defaultValueJsonDeserialized = jsonSerialization.deserializeList(Integer.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<Integer> borderValue1 = new java.util.ArrayList<Integer>(java.util.Arrays.asList(0));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<Integer> borderValue1JsonDeserialized = jsonSerialization.deserializeList(Integer.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<Integer> borderValue2 = new java.util.ArrayList<Integer>(java.util.Arrays.asList(1000000000));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<Integer> borderValue2JsonDeserialized = jsonSerialization.deserializeList(Integer.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<Integer> borderValue3 = new java.util.ArrayList<Integer>(java.util.Arrays.asList(0, Integer.MIN_VALUE, Integer.MAX_VALUE, -1000000000, 1000000000));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<Integer> borderValue3JsonDeserialized = jsonSerialization.deserializeList(Integer.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Integer/OneSetOfNullableIntegersDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Integer/OneSetOfNullableIntegersDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Integer;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfNullableIntegersDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<Integer> defaultValue = new java.util.HashSet<Integer>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<Integer> defaultValueJsonDeserialized = new java.util.HashSet<Integer>(jsonSerialization.deserializeList(Integer.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<Integer> borderValue1 = new java.util.HashSet<Integer>(java.util.Arrays.asList((Integer) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<Integer> borderValue1JsonDeserialized = new java.util.HashSet<Integer>(jsonSerialization.deserializeList(Integer.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<Integer> borderValue2 = new java.util.HashSet<Integer>(java.util.Arrays.asList(0));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<Integer> borderValue2JsonDeserialized = new java.util.HashSet<Integer>(jsonSerialization.deserializeList(Integer.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<Integer> borderValue3 = new java.util.HashSet<Integer>(java.util.Arrays.asList(1000000000));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<Integer> borderValue3JsonDeserialized = new java.util.HashSet<Integer>(jsonSerialization.deserializeList(Integer.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<Integer> borderValue4 = new java.util.HashSet<Integer>(java.util.Arrays.asList(0, Integer.MIN_VALUE, Integer.MAX_VALUE, -1000000000, 1000000000));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<Integer> borderValue4JsonDeserialized = new java.util.HashSet<Integer>(jsonSerialization.deserializeList(Integer.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<Integer> borderValue5 = new java.util.HashSet<Integer>(java.util.Arrays.asList((Integer) null, 0, Integer.MIN_VALUE, Integer.MAX_VALUE, -1000000000, 1000000000));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<Integer> borderValue5JsonDeserialized = new java.util.HashSet<Integer>(jsonSerialization.deserializeList(Integer.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Integer/OneSetOfOneIntegersDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Integer/OneSetOfOneIntegersDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Integer;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfOneIntegersDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<Integer> defaultValue = new java.util.HashSet<Integer>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<Integer> defaultValueJsonDeserialized = new java.util.HashSet<Integer>(jsonSerialization.deserializeList(Integer.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<Integer> borderValue1 = new java.util.HashSet<Integer>(java.util.Arrays.asList(0));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<Integer> borderValue1JsonDeserialized = new java.util.HashSet<Integer>(jsonSerialization.deserializeList(Integer.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<Integer> borderValue2 = new java.util.HashSet<Integer>(java.util.Arrays.asList(1000000000));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<Integer> borderValue2JsonDeserialized = new java.util.HashSet<Integer>(jsonSerialization.deserializeList(Integer.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<Integer> borderValue3 = new java.util.HashSet<Integer>(java.util.Arrays.asList(0, Integer.MIN_VALUE, Integer.MAX_VALUE, -1000000000, 1000000000));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<Integer> borderValue3JsonDeserialized = new java.util.HashSet<Integer>(jsonSerialization.deserializeList(Integer.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IntegerAsserts.assertOneSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Ip/NullableArrayOfNullableIpsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Ip/NullableArrayOfNullableIpsDefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Ip;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfNullableIpsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.net.InetAddress[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.net.InetAddress[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.net.InetAddress[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.net.InetAddress[] borderValue1 = new java.net.InetAddress[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.net.InetAddress[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.net.InetAddress[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.net.InetAddress[] borderValue2 = new java.net.InetAddress[] { com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff") };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.net.InetAddress[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.net.InetAddress[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.net.InetAddress[] borderValue3 = new java.net.InetAddress[] { com.dslplatform.ocd.test.TypeFactory.buildIP("127.0.0.1"), com.dslplatform.ocd.test.TypeFactory.buildIP("0"), com.dslplatform.ocd.test.TypeFactory.buildIP("255.255.255.255"), com.dslplatform.ocd.test.TypeFactory.buildIP("::1"), com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff") };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.net.InetAddress[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.net.InetAddress[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.net.InetAddress[] borderValue4 = new java.net.InetAddress[] { null, com.dslplatform.ocd.test.TypeFactory.buildIP("127.0.0.1"), com.dslplatform.ocd.test.TypeFactory.buildIP("0"), com.dslplatform.ocd.test.TypeFactory.buildIP("255.255.255.255"), com.dslplatform.ocd.test.TypeFactory.buildIP("::1"), com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff") };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.net.InetAddress[] borderValue4JsonDeserialized = jsonSerialization.deserialize(java.net.InetAddress[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Ip/NullableArrayOfOneIpsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Ip/NullableArrayOfOneIpsDefaultValueTurtle.java
@@ -1,0 +1,46 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Ip;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfOneIpsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.net.InetAddress[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.net.InetAddress[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.net.InetAddress[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.net.InetAddress[] borderValue1 = new java.net.InetAddress[] { com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff") };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.net.InetAddress[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.net.InetAddress[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.net.InetAddress[] borderValue2 = new java.net.InetAddress[] { com.dslplatform.ocd.test.TypeFactory.buildIP("127.0.0.1"), com.dslplatform.ocd.test.TypeFactory.buildIP("0"), com.dslplatform.ocd.test.TypeFactory.buildIP("255.255.255.255"), com.dslplatform.ocd.test.TypeFactory.buildIP("::1"), com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff") };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.net.InetAddress[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.net.InetAddress[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Ip/NullableIpDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Ip/NullableIpDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Ip;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableIpDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.net.InetAddress defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.net.InetAddress defaultValueJsonDeserialized = jsonSerialization.deserialize(java.net.InetAddress.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.net.InetAddress borderValue1 = com.dslplatform.ocd.test.TypeFactory.buildIP("127.0.0.1");
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.net.InetAddress borderValue1JsonDeserialized = jsonSerialization.deserialize(java.net.InetAddress.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.net.InetAddress borderValue2 = com.dslplatform.ocd.test.TypeFactory.buildIP("0");
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.net.InetAddress borderValue2JsonDeserialized = jsonSerialization.deserialize(java.net.InetAddress.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.net.InetAddress borderValue3 = com.dslplatform.ocd.test.TypeFactory.buildIP("255.255.255.255");
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.net.InetAddress borderValue3JsonDeserialized = jsonSerialization.deserialize(java.net.InetAddress.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.net.InetAddress borderValue4 = com.dslplatform.ocd.test.TypeFactory.buildIP("::1");
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.net.InetAddress borderValue4JsonDeserialized = jsonSerialization.deserialize(java.net.InetAddress.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.net.InetAddress borderValue5 = com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff");
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.net.InetAddress borderValue5JsonDeserialized = jsonSerialization.deserialize(java.net.InetAddress.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Ip/NullableListOfNullableIpsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Ip/NullableListOfNullableIpsDefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Ip;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfNullableIpsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.net.InetAddress> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.net.InetAddress> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.net.InetAddress.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.net.InetAddress> borderValue1 = new java.util.ArrayList<java.net.InetAddress>(java.util.Arrays.asList((java.net.InetAddress) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.net.InetAddress> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.net.InetAddress.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.net.InetAddress> borderValue2 = new java.util.ArrayList<java.net.InetAddress>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.net.InetAddress> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.net.InetAddress.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.net.InetAddress> borderValue3 = new java.util.ArrayList<java.net.InetAddress>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildIP("127.0.0.1"), com.dslplatform.ocd.test.TypeFactory.buildIP("0"), com.dslplatform.ocd.test.TypeFactory.buildIP("255.255.255.255"), com.dslplatform.ocd.test.TypeFactory.buildIP("::1"), com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.net.InetAddress> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.net.InetAddress.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<java.net.InetAddress> borderValue4 = new java.util.ArrayList<java.net.InetAddress>(java.util.Arrays.asList((java.net.InetAddress) null, com.dslplatform.ocd.test.TypeFactory.buildIP("127.0.0.1"), com.dslplatform.ocd.test.TypeFactory.buildIP("0"), com.dslplatform.ocd.test.TypeFactory.buildIP("255.255.255.255"), com.dslplatform.ocd.test.TypeFactory.buildIP("::1"), com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff")));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<java.net.InetAddress> borderValue4JsonDeserialized = jsonSerialization.deserializeList(java.net.InetAddress.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Ip/NullableListOfOneIpsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Ip/NullableListOfOneIpsDefaultValueTurtle.java
@@ -1,0 +1,46 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Ip;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfOneIpsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.net.InetAddress> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.net.InetAddress> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.net.InetAddress.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.net.InetAddress> borderValue1 = new java.util.ArrayList<java.net.InetAddress>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff")));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.net.InetAddress> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.net.InetAddress.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.net.InetAddress> borderValue2 = new java.util.ArrayList<java.net.InetAddress>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildIP("127.0.0.1"), com.dslplatform.ocd.test.TypeFactory.buildIP("0"), com.dslplatform.ocd.test.TypeFactory.buildIP("255.255.255.255"), com.dslplatform.ocd.test.TypeFactory.buildIP("::1"), com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.net.InetAddress> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.net.InetAddress.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Ip/NullableSetOfNullableIpsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Ip/NullableSetOfNullableIpsDefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Ip;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfNullableIpsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.net.InetAddress> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.net.InetAddress> defaultValueJsonDeserialized = new java.util.HashSet<java.net.InetAddress>(jsonSerialization.deserializeList(java.net.InetAddress.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.net.InetAddress> borderValue1 = new java.util.HashSet<java.net.InetAddress>(java.util.Arrays.asList((java.net.InetAddress) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.net.InetAddress> borderValue1JsonDeserialized = new java.util.HashSet<java.net.InetAddress>(jsonSerialization.deserializeList(java.net.InetAddress.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.net.InetAddress> borderValue2 = new java.util.HashSet<java.net.InetAddress>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.net.InetAddress> borderValue2JsonDeserialized = new java.util.HashSet<java.net.InetAddress>(jsonSerialization.deserializeList(java.net.InetAddress.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.net.InetAddress> borderValue3 = new java.util.HashSet<java.net.InetAddress>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildIP("127.0.0.1"), com.dslplatform.ocd.test.TypeFactory.buildIP("0"), com.dslplatform.ocd.test.TypeFactory.buildIP("255.255.255.255"), com.dslplatform.ocd.test.TypeFactory.buildIP("::1"), com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.net.InetAddress> borderValue3JsonDeserialized = new java.util.HashSet<java.net.InetAddress>(jsonSerialization.deserializeList(java.net.InetAddress.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<java.net.InetAddress> borderValue4 = new java.util.HashSet<java.net.InetAddress>(java.util.Arrays.asList((java.net.InetAddress) null, com.dslplatform.ocd.test.TypeFactory.buildIP("127.0.0.1"), com.dslplatform.ocd.test.TypeFactory.buildIP("0"), com.dslplatform.ocd.test.TypeFactory.buildIP("255.255.255.255"), com.dslplatform.ocd.test.TypeFactory.buildIP("::1"), com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff")));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<java.net.InetAddress> borderValue4JsonDeserialized = new java.util.HashSet<java.net.InetAddress>(jsonSerialization.deserializeList(java.net.InetAddress.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Ip/NullableSetOfOneIpsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Ip/NullableSetOfOneIpsDefaultValueTurtle.java
@@ -1,0 +1,46 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Ip;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfOneIpsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.net.InetAddress> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.net.InetAddress> defaultValueJsonDeserialized = new java.util.HashSet<java.net.InetAddress>(jsonSerialization.deserializeList(java.net.InetAddress.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.net.InetAddress> borderValue1 = new java.util.HashSet<java.net.InetAddress>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff")));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.net.InetAddress> borderValue1JsonDeserialized = new java.util.HashSet<java.net.InetAddress>(jsonSerialization.deserializeList(java.net.InetAddress.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.net.InetAddress> borderValue2 = new java.util.HashSet<java.net.InetAddress>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildIP("127.0.0.1"), com.dslplatform.ocd.test.TypeFactory.buildIP("0"), com.dslplatform.ocd.test.TypeFactory.buildIP("255.255.255.255"), com.dslplatform.ocd.test.TypeFactory.buildIP("::1"), com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.net.InetAddress> borderValue2JsonDeserialized = new java.util.HashSet<java.net.InetAddress>(jsonSerialization.deserializeList(java.net.InetAddress.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertNullableSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Ip/OneArrayOfNullableIpsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Ip/OneArrayOfNullableIpsDefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Ip;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfNullableIpsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.net.InetAddress[] defaultValue = new java.net.InetAddress[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.net.InetAddress[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.net.InetAddress[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertOneArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.net.InetAddress[] borderValue1 = new java.net.InetAddress[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.net.InetAddress[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.net.InetAddress[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertOneArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.net.InetAddress[] borderValue2 = new java.net.InetAddress[] { com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff") };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.net.InetAddress[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.net.InetAddress[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertOneArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.net.InetAddress[] borderValue3 = new java.net.InetAddress[] { com.dslplatform.ocd.test.TypeFactory.buildIP("127.0.0.1"), com.dslplatform.ocd.test.TypeFactory.buildIP("0"), com.dslplatform.ocd.test.TypeFactory.buildIP("255.255.255.255"), com.dslplatform.ocd.test.TypeFactory.buildIP("::1"), com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff") };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.net.InetAddress[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.net.InetAddress[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertOneArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.net.InetAddress[] borderValue4 = new java.net.InetAddress[] { null, com.dslplatform.ocd.test.TypeFactory.buildIP("127.0.0.1"), com.dslplatform.ocd.test.TypeFactory.buildIP("0"), com.dslplatform.ocd.test.TypeFactory.buildIP("255.255.255.255"), com.dslplatform.ocd.test.TypeFactory.buildIP("::1"), com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff") };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.net.InetAddress[] borderValue4JsonDeserialized = jsonSerialization.deserialize(java.net.InetAddress[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertOneArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Ip/OneArrayOfOneIpsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Ip/OneArrayOfOneIpsDefaultValueTurtle.java
@@ -1,0 +1,46 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Ip;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfOneIpsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.net.InetAddress[] defaultValue = new java.net.InetAddress[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.net.InetAddress[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.net.InetAddress[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertOneArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.net.InetAddress[] borderValue1 = new java.net.InetAddress[] { com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff") };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.net.InetAddress[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.net.InetAddress[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertOneArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.net.InetAddress[] borderValue2 = new java.net.InetAddress[] { com.dslplatform.ocd.test.TypeFactory.buildIP("127.0.0.1"), com.dslplatform.ocd.test.TypeFactory.buildIP("0"), com.dslplatform.ocd.test.TypeFactory.buildIP("255.255.255.255"), com.dslplatform.ocd.test.TypeFactory.buildIP("::1"), com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff") };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.net.InetAddress[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.net.InetAddress[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertOneArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Ip/OneIpDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Ip/OneIpDefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Ip;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneIpDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.net.InetAddress defaultValue = com.dslplatform.ocd.test.TypeFactory.buildIP("127.0.0.1");
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.net.InetAddress defaultValueJsonDeserialized = jsonSerialization.deserialize(java.net.InetAddress.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.net.InetAddress borderValue1 = com.dslplatform.ocd.test.TypeFactory.buildIP("0");
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.net.InetAddress borderValue1JsonDeserialized = jsonSerialization.deserialize(java.net.InetAddress.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.net.InetAddress borderValue2 = com.dslplatform.ocd.test.TypeFactory.buildIP("255.255.255.255");
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.net.InetAddress borderValue2JsonDeserialized = jsonSerialization.deserialize(java.net.InetAddress.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.net.InetAddress borderValue3 = com.dslplatform.ocd.test.TypeFactory.buildIP("::1");
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.net.InetAddress borderValue3JsonDeserialized = jsonSerialization.deserialize(java.net.InetAddress.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.net.InetAddress borderValue4 = com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff");
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.net.InetAddress borderValue4JsonDeserialized = jsonSerialization.deserialize(java.net.InetAddress.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertOneEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Ip/OneListOfNullableIpsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Ip/OneListOfNullableIpsDefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Ip;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfNullableIpsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.net.InetAddress> defaultValue = new java.util.ArrayList<java.net.InetAddress>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.net.InetAddress> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.net.InetAddress.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertOneListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.net.InetAddress> borderValue1 = new java.util.ArrayList<java.net.InetAddress>(java.util.Arrays.asList((java.net.InetAddress) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.net.InetAddress> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.net.InetAddress.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertOneListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.net.InetAddress> borderValue2 = new java.util.ArrayList<java.net.InetAddress>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.net.InetAddress> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.net.InetAddress.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertOneListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.net.InetAddress> borderValue3 = new java.util.ArrayList<java.net.InetAddress>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildIP("127.0.0.1"), com.dslplatform.ocd.test.TypeFactory.buildIP("0"), com.dslplatform.ocd.test.TypeFactory.buildIP("255.255.255.255"), com.dslplatform.ocd.test.TypeFactory.buildIP("::1"), com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.net.InetAddress> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.net.InetAddress.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertOneListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<java.net.InetAddress> borderValue4 = new java.util.ArrayList<java.net.InetAddress>(java.util.Arrays.asList((java.net.InetAddress) null, com.dslplatform.ocd.test.TypeFactory.buildIP("127.0.0.1"), com.dslplatform.ocd.test.TypeFactory.buildIP("0"), com.dslplatform.ocd.test.TypeFactory.buildIP("255.255.255.255"), com.dslplatform.ocd.test.TypeFactory.buildIP("::1"), com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff")));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<java.net.InetAddress> borderValue4JsonDeserialized = jsonSerialization.deserializeList(java.net.InetAddress.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertOneListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Ip/OneListOfOneIpsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Ip/OneListOfOneIpsDefaultValueTurtle.java
@@ -1,0 +1,46 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Ip;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfOneIpsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.net.InetAddress> defaultValue = new java.util.ArrayList<java.net.InetAddress>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.net.InetAddress> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.net.InetAddress.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertOneListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.net.InetAddress> borderValue1 = new java.util.ArrayList<java.net.InetAddress>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff")));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.net.InetAddress> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.net.InetAddress.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertOneListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.net.InetAddress> borderValue2 = new java.util.ArrayList<java.net.InetAddress>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildIP("127.0.0.1"), com.dslplatform.ocd.test.TypeFactory.buildIP("0"), com.dslplatform.ocd.test.TypeFactory.buildIP("255.255.255.255"), com.dslplatform.ocd.test.TypeFactory.buildIP("::1"), com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.net.InetAddress> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.net.InetAddress.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertOneListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Ip/OneSetOfNullableIpsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Ip/OneSetOfNullableIpsDefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Ip;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfNullableIpsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.net.InetAddress> defaultValue = new java.util.HashSet<java.net.InetAddress>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.net.InetAddress> defaultValueJsonDeserialized = new java.util.HashSet<java.net.InetAddress>(jsonSerialization.deserializeList(java.net.InetAddress.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertOneSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.net.InetAddress> borderValue1 = new java.util.HashSet<java.net.InetAddress>(java.util.Arrays.asList((java.net.InetAddress) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.net.InetAddress> borderValue1JsonDeserialized = new java.util.HashSet<java.net.InetAddress>(jsonSerialization.deserializeList(java.net.InetAddress.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertOneSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.net.InetAddress> borderValue2 = new java.util.HashSet<java.net.InetAddress>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.net.InetAddress> borderValue2JsonDeserialized = new java.util.HashSet<java.net.InetAddress>(jsonSerialization.deserializeList(java.net.InetAddress.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertOneSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.net.InetAddress> borderValue3 = new java.util.HashSet<java.net.InetAddress>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildIP("127.0.0.1"), com.dslplatform.ocd.test.TypeFactory.buildIP("0"), com.dslplatform.ocd.test.TypeFactory.buildIP("255.255.255.255"), com.dslplatform.ocd.test.TypeFactory.buildIP("::1"), com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.net.InetAddress> borderValue3JsonDeserialized = new java.util.HashSet<java.net.InetAddress>(jsonSerialization.deserializeList(java.net.InetAddress.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertOneSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<java.net.InetAddress> borderValue4 = new java.util.HashSet<java.net.InetAddress>(java.util.Arrays.asList((java.net.InetAddress) null, com.dslplatform.ocd.test.TypeFactory.buildIP("127.0.0.1"), com.dslplatform.ocd.test.TypeFactory.buildIP("0"), com.dslplatform.ocd.test.TypeFactory.buildIP("255.255.255.255"), com.dslplatform.ocd.test.TypeFactory.buildIP("::1"), com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff")));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<java.net.InetAddress> borderValue4JsonDeserialized = new java.util.HashSet<java.net.InetAddress>(jsonSerialization.deserializeList(java.net.InetAddress.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertOneSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Ip/OneSetOfOneIpsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Ip/OneSetOfOneIpsDefaultValueTurtle.java
@@ -1,0 +1,46 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Ip;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfOneIpsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.net.InetAddress> defaultValue = new java.util.HashSet<java.net.InetAddress>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.net.InetAddress> defaultValueJsonDeserialized = new java.util.HashSet<java.net.InetAddress>(jsonSerialization.deserializeList(java.net.InetAddress.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertOneSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.net.InetAddress> borderValue1 = new java.util.HashSet<java.net.InetAddress>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff")));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.net.InetAddress> borderValue1JsonDeserialized = new java.util.HashSet<java.net.InetAddress>(jsonSerialization.deserializeList(java.net.InetAddress.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertOneSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.net.InetAddress> borderValue2 = new java.util.HashSet<java.net.InetAddress>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildIP("127.0.0.1"), com.dslplatform.ocd.test.TypeFactory.buildIP("0"), com.dslplatform.ocd.test.TypeFactory.buildIP("255.255.255.255"), com.dslplatform.ocd.test.TypeFactory.buildIP("::1"), com.dslplatform.ocd.test.TypeFactory.buildIP("ffff::ffff")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.net.InetAddress> borderValue2JsonDeserialized = new java.util.HashSet<java.net.InetAddress>(jsonSerialization.deserializeList(java.net.InetAddress.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.IpAsserts.assertOneSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Location/NullableArrayOfNullableLocationsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Location/NullableArrayOfNullableLocationsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Location;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfNullableLocationsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.awt.geom.Point2D[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.awt.geom.Point2D[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.awt.geom.Point2D[] borderValue1 = new java.awt.geom.Point2D[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.awt.geom.Point2D[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.awt.geom.Point2D[] borderValue2 = new java.awt.geom.Point2D[] { new java.awt.geom.Point2D.Float() };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.awt.geom.Point2D[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.awt.geom.Point2D[] borderValue3 = new java.awt.geom.Point2D[] { new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001) };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.awt.geom.Point2D[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.awt.geom.Point2D[] borderValue4 = new java.awt.geom.Point2D[] { new java.awt.geom.Point2D.Float(), new java.awt.Point(Integer.MIN_VALUE, Integer.MAX_VALUE), new java.awt.Point(-1000000000, 1000000000), new java.awt.geom.Point2D.Float(Float.MIN_VALUE, Float.MAX_VALUE), new java.awt.geom.Point2D.Float(-1.0000001f, 1.0000001f), new java.awt.geom.Point2D.Double(Double.MIN_VALUE, Double.MAX_VALUE), new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001) };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.awt.geom.Point2D[] borderValue4JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.awt.geom.Point2D[] borderValue5 = new java.awt.geom.Point2D[] { null, new java.awt.geom.Point2D.Float(), new java.awt.Point(Integer.MIN_VALUE, Integer.MAX_VALUE), new java.awt.Point(-1000000000, 1000000000), new java.awt.geom.Point2D.Float(Float.MIN_VALUE, Float.MAX_VALUE), new java.awt.geom.Point2D.Float(-1.0000001f, 1.0000001f), new java.awt.geom.Point2D.Double(Double.MIN_VALUE, Double.MAX_VALUE), new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001) };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.awt.geom.Point2D[] borderValue5JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Location/NullableArrayOfOneLocationsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Location/NullableArrayOfOneLocationsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Location;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfOneLocationsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.awt.geom.Point2D[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.awt.geom.Point2D[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.awt.geom.Point2D[] borderValue1 = new java.awt.geom.Point2D[] { new java.awt.geom.Point2D.Float() };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.awt.geom.Point2D[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.awt.geom.Point2D[] borderValue2 = new java.awt.geom.Point2D[] { new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001) };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.awt.geom.Point2D[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.awt.geom.Point2D[] borderValue3 = new java.awt.geom.Point2D[] { new java.awt.geom.Point2D.Float(), new java.awt.Point(Integer.MIN_VALUE, Integer.MAX_VALUE), new java.awt.Point(-1000000000, 1000000000), new java.awt.geom.Point2D.Float(Float.MIN_VALUE, Float.MAX_VALUE), new java.awt.geom.Point2D.Float(-1.0000001f, 1.0000001f), new java.awt.geom.Point2D.Double(Double.MIN_VALUE, Double.MAX_VALUE), new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001) };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.awt.geom.Point2D[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Location/NullableListOfNullableLocationsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Location/NullableListOfNullableLocationsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Location;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfNullableLocationsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.awt.geom.Point2D> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.awt.geom.Point2D> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Point2D.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.awt.geom.Point2D> borderValue1 = new java.util.ArrayList<java.awt.geom.Point2D>(java.util.Arrays.asList((java.awt.geom.Point2D) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.awt.geom.Point2D> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.awt.geom.Point2D> borderValue2 = new java.util.ArrayList<java.awt.geom.Point2D>(java.util.Arrays.asList(new java.awt.geom.Point2D.Float()));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.awt.geom.Point2D> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.awt.geom.Point2D> borderValue3 = new java.util.ArrayList<java.awt.geom.Point2D>(java.util.Arrays.asList(new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.awt.geom.Point2D> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<java.awt.geom.Point2D> borderValue4 = new java.util.ArrayList<java.awt.geom.Point2D>(java.util.Arrays.asList(new java.awt.geom.Point2D.Float(), new java.awt.Point(Integer.MIN_VALUE, Integer.MAX_VALUE), new java.awt.Point(-1000000000, 1000000000), new java.awt.geom.Point2D.Float(Float.MIN_VALUE, Float.MAX_VALUE), new java.awt.geom.Point2D.Float(-1.0000001f, 1.0000001f), new java.awt.geom.Point2D.Double(Double.MIN_VALUE, Double.MAX_VALUE), new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<java.awt.geom.Point2D> borderValue4JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<java.awt.geom.Point2D> borderValue5 = new java.util.ArrayList<java.awt.geom.Point2D>(java.util.Arrays.asList((java.awt.geom.Point2D) null, new java.awt.geom.Point2D.Float(), new java.awt.Point(Integer.MIN_VALUE, Integer.MAX_VALUE), new java.awt.Point(-1000000000, 1000000000), new java.awt.geom.Point2D.Float(Float.MIN_VALUE, Float.MAX_VALUE), new java.awt.geom.Point2D.Float(-1.0000001f, 1.0000001f), new java.awt.geom.Point2D.Double(Double.MIN_VALUE, Double.MAX_VALUE), new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<java.awt.geom.Point2D> borderValue5JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Location/NullableListOfOneLocationsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Location/NullableListOfOneLocationsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Location;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfOneLocationsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.awt.geom.Point2D> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.awt.geom.Point2D> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Point2D.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.awt.geom.Point2D> borderValue1 = new java.util.ArrayList<java.awt.geom.Point2D>(java.util.Arrays.asList(new java.awt.geom.Point2D.Float()));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.awt.geom.Point2D> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.awt.geom.Point2D> borderValue2 = new java.util.ArrayList<java.awt.geom.Point2D>(java.util.Arrays.asList(new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.awt.geom.Point2D> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.awt.geom.Point2D> borderValue3 = new java.util.ArrayList<java.awt.geom.Point2D>(java.util.Arrays.asList(new java.awt.geom.Point2D.Float(), new java.awt.Point(Integer.MIN_VALUE, Integer.MAX_VALUE), new java.awt.Point(-1000000000, 1000000000), new java.awt.geom.Point2D.Float(Float.MIN_VALUE, Float.MAX_VALUE), new java.awt.geom.Point2D.Float(-1.0000001f, 1.0000001f), new java.awt.geom.Point2D.Double(Double.MIN_VALUE, Double.MAX_VALUE), new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.awt.geom.Point2D> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Location/NullableLocationDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Location/NullableLocationDefaultValueTurtle.java
@@ -1,0 +1,91 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Location;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableLocationDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.awt.geom.Point2D defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.awt.geom.Point2D defaultValueJsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.awt.geom.Point2D borderValue1 = new java.awt.geom.Point2D.Float();
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.awt.geom.Point2D borderValue1JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.awt.geom.Point2D borderValue2 = new java.awt.Point(Integer.MIN_VALUE, Integer.MAX_VALUE);
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.awt.geom.Point2D borderValue2JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.awt.geom.Point2D borderValue3 = new java.awt.Point(-1000000000, 1000000000);
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.awt.geom.Point2D borderValue3JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.awt.geom.Point2D borderValue4 = new java.awt.geom.Point2D.Float(Float.MIN_VALUE, Float.MAX_VALUE);
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.awt.geom.Point2D borderValue4JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.awt.geom.Point2D borderValue5 = new java.awt.geom.Point2D.Float(-1.0000001f, 1.0000001f);
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.awt.geom.Point2D borderValue5JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue6Equality() throws IOException {
+        final java.awt.geom.Point2D borderValue6 = new java.awt.geom.Point2D.Double(Double.MIN_VALUE, Double.MAX_VALUE);
+        final Bytes borderValue6JsonSerialized = jsonSerialization.serialize(borderValue6);
+        final java.awt.geom.Point2D borderValue6JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D.class, borderValue6JsonSerialized.content, borderValue6JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableEquals(borderValue6, borderValue6JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue7Equality() throws IOException {
+        final java.awt.geom.Point2D borderValue7 = new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001);
+        final Bytes borderValue7JsonSerialized = jsonSerialization.serialize(borderValue7);
+        final java.awt.geom.Point2D borderValue7JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D.class, borderValue7JsonSerialized.content, borderValue7JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableEquals(borderValue7, borderValue7JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Location/NullableSetOfNullableLocationsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Location/NullableSetOfNullableLocationsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Location;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfNullableLocationsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.awt.geom.Point2D> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.awt.geom.Point2D> defaultValueJsonDeserialized = new java.util.HashSet<java.awt.geom.Point2D>(jsonSerialization.deserializeList(java.awt.geom.Point2D.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Point2D> borderValue1 = new java.util.HashSet<java.awt.geom.Point2D>(java.util.Arrays.asList((java.awt.geom.Point2D) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.awt.geom.Point2D> borderValue1JsonDeserialized = new java.util.HashSet<java.awt.geom.Point2D>(jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Point2D> borderValue2 = new java.util.HashSet<java.awt.geom.Point2D>(java.util.Arrays.asList(new java.awt.geom.Point2D.Float()));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.awt.geom.Point2D> borderValue2JsonDeserialized = new java.util.HashSet<java.awt.geom.Point2D>(jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Point2D> borderValue3 = new java.util.HashSet<java.awt.geom.Point2D>(java.util.Arrays.asList(new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.awt.geom.Point2D> borderValue3JsonDeserialized = new java.util.HashSet<java.awt.geom.Point2D>(jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Point2D> borderValue4 = new java.util.HashSet<java.awt.geom.Point2D>(java.util.Arrays.asList(new java.awt.geom.Point2D.Float(), new java.awt.Point(Integer.MIN_VALUE, Integer.MAX_VALUE), new java.awt.Point(-1000000000, 1000000000), new java.awt.geom.Point2D.Float(Float.MIN_VALUE, Float.MAX_VALUE), new java.awt.geom.Point2D.Float(-1.0000001f, 1.0000001f), new java.awt.geom.Point2D.Double(Double.MIN_VALUE, Double.MAX_VALUE), new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<java.awt.geom.Point2D> borderValue4JsonDeserialized = new java.util.HashSet<java.awt.geom.Point2D>(jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Point2D> borderValue5 = new java.util.HashSet<java.awt.geom.Point2D>(java.util.Arrays.asList((java.awt.geom.Point2D) null, new java.awt.geom.Point2D.Float(), new java.awt.Point(Integer.MIN_VALUE, Integer.MAX_VALUE), new java.awt.Point(-1000000000, 1000000000), new java.awt.geom.Point2D.Float(Float.MIN_VALUE, Float.MAX_VALUE), new java.awt.geom.Point2D.Float(-1.0000001f, 1.0000001f), new java.awt.geom.Point2D.Double(Double.MIN_VALUE, Double.MAX_VALUE), new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<java.awt.geom.Point2D> borderValue5JsonDeserialized = new java.util.HashSet<java.awt.geom.Point2D>(jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Location/NullableSetOfOneLocationsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Location/NullableSetOfOneLocationsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Location;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfOneLocationsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.awt.geom.Point2D> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.awt.geom.Point2D> defaultValueJsonDeserialized = new java.util.HashSet<java.awt.geom.Point2D>(jsonSerialization.deserializeList(java.awt.geom.Point2D.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Point2D> borderValue1 = new java.util.HashSet<java.awt.geom.Point2D>(java.util.Arrays.asList(new java.awt.geom.Point2D.Float()));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.awt.geom.Point2D> borderValue1JsonDeserialized = new java.util.HashSet<java.awt.geom.Point2D>(jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Point2D> borderValue2 = new java.util.HashSet<java.awt.geom.Point2D>(java.util.Arrays.asList(new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.awt.geom.Point2D> borderValue2JsonDeserialized = new java.util.HashSet<java.awt.geom.Point2D>(jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Point2D> borderValue3 = new java.util.HashSet<java.awt.geom.Point2D>(java.util.Arrays.asList(new java.awt.geom.Point2D.Float(), new java.awt.Point(Integer.MIN_VALUE, Integer.MAX_VALUE), new java.awt.Point(-1000000000, 1000000000), new java.awt.geom.Point2D.Float(Float.MIN_VALUE, Float.MAX_VALUE), new java.awt.geom.Point2D.Float(-1.0000001f, 1.0000001f), new java.awt.geom.Point2D.Double(Double.MIN_VALUE, Double.MAX_VALUE), new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.awt.geom.Point2D> borderValue3JsonDeserialized = new java.util.HashSet<java.awt.geom.Point2D>(jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertNullableSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Location/OneArrayOfNullableLocationsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Location/OneArrayOfNullableLocationsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Location;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfNullableLocationsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.awt.geom.Point2D[] defaultValue = new java.awt.geom.Point2D[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.awt.geom.Point2D[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.awt.geom.Point2D[] borderValue1 = new java.awt.geom.Point2D[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.awt.geom.Point2D[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.awt.geom.Point2D[] borderValue2 = new java.awt.geom.Point2D[] { new java.awt.geom.Point2D.Float() };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.awt.geom.Point2D[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.awt.geom.Point2D[] borderValue3 = new java.awt.geom.Point2D[] { new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001) };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.awt.geom.Point2D[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.awt.geom.Point2D[] borderValue4 = new java.awt.geom.Point2D[] { new java.awt.geom.Point2D.Float(), new java.awt.Point(Integer.MIN_VALUE, Integer.MAX_VALUE), new java.awt.Point(-1000000000, 1000000000), new java.awt.geom.Point2D.Float(Float.MIN_VALUE, Float.MAX_VALUE), new java.awt.geom.Point2D.Float(-1.0000001f, 1.0000001f), new java.awt.geom.Point2D.Double(Double.MIN_VALUE, Double.MAX_VALUE), new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001) };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.awt.geom.Point2D[] borderValue4JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.awt.geom.Point2D[] borderValue5 = new java.awt.geom.Point2D[] { null, new java.awt.geom.Point2D.Float(), new java.awt.Point(Integer.MIN_VALUE, Integer.MAX_VALUE), new java.awt.Point(-1000000000, 1000000000), new java.awt.geom.Point2D.Float(Float.MIN_VALUE, Float.MAX_VALUE), new java.awt.geom.Point2D.Float(-1.0000001f, 1.0000001f), new java.awt.geom.Point2D.Double(Double.MIN_VALUE, Double.MAX_VALUE), new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001) };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.awt.geom.Point2D[] borderValue5JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Location/OneArrayOfOneLocationsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Location/OneArrayOfOneLocationsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Location;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfOneLocationsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.awt.geom.Point2D[] defaultValue = new java.awt.geom.Point2D[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.awt.geom.Point2D[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.awt.geom.Point2D[] borderValue1 = new java.awt.geom.Point2D[] { new java.awt.geom.Point2D.Float() };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.awt.geom.Point2D[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.awt.geom.Point2D[] borderValue2 = new java.awt.geom.Point2D[] { new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001) };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.awt.geom.Point2D[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.awt.geom.Point2D[] borderValue3 = new java.awt.geom.Point2D[] { new java.awt.geom.Point2D.Float(), new java.awt.Point(Integer.MIN_VALUE, Integer.MAX_VALUE), new java.awt.Point(-1000000000, 1000000000), new java.awt.geom.Point2D.Float(Float.MIN_VALUE, Float.MAX_VALUE), new java.awt.geom.Point2D.Float(-1.0000001f, 1.0000001f), new java.awt.geom.Point2D.Double(Double.MIN_VALUE, Double.MAX_VALUE), new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001) };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.awt.geom.Point2D[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Location/OneListOfNullableLocationsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Location/OneListOfNullableLocationsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Location;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfNullableLocationsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.awt.geom.Point2D> defaultValue = new java.util.ArrayList<java.awt.geom.Point2D>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.awt.geom.Point2D> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Point2D.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.awt.geom.Point2D> borderValue1 = new java.util.ArrayList<java.awt.geom.Point2D>(java.util.Arrays.asList((java.awt.geom.Point2D) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.awt.geom.Point2D> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.awt.geom.Point2D> borderValue2 = new java.util.ArrayList<java.awt.geom.Point2D>(java.util.Arrays.asList(new java.awt.geom.Point2D.Float()));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.awt.geom.Point2D> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.awt.geom.Point2D> borderValue3 = new java.util.ArrayList<java.awt.geom.Point2D>(java.util.Arrays.asList(new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.awt.geom.Point2D> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<java.awt.geom.Point2D> borderValue4 = new java.util.ArrayList<java.awt.geom.Point2D>(java.util.Arrays.asList(new java.awt.geom.Point2D.Float(), new java.awt.Point(Integer.MIN_VALUE, Integer.MAX_VALUE), new java.awt.Point(-1000000000, 1000000000), new java.awt.geom.Point2D.Float(Float.MIN_VALUE, Float.MAX_VALUE), new java.awt.geom.Point2D.Float(-1.0000001f, 1.0000001f), new java.awt.geom.Point2D.Double(Double.MIN_VALUE, Double.MAX_VALUE), new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<java.awt.geom.Point2D> borderValue4JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<java.awt.geom.Point2D> borderValue5 = new java.util.ArrayList<java.awt.geom.Point2D>(java.util.Arrays.asList((java.awt.geom.Point2D) null, new java.awt.geom.Point2D.Float(), new java.awt.Point(Integer.MIN_VALUE, Integer.MAX_VALUE), new java.awt.Point(-1000000000, 1000000000), new java.awt.geom.Point2D.Float(Float.MIN_VALUE, Float.MAX_VALUE), new java.awt.geom.Point2D.Float(-1.0000001f, 1.0000001f), new java.awt.geom.Point2D.Double(Double.MIN_VALUE, Double.MAX_VALUE), new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<java.awt.geom.Point2D> borderValue5JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Location/OneListOfOneLocationsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Location/OneListOfOneLocationsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Location;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfOneLocationsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.awt.geom.Point2D> defaultValue = new java.util.ArrayList<java.awt.geom.Point2D>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.awt.geom.Point2D> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Point2D.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.awt.geom.Point2D> borderValue1 = new java.util.ArrayList<java.awt.geom.Point2D>(java.util.Arrays.asList(new java.awt.geom.Point2D.Float()));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.awt.geom.Point2D> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.awt.geom.Point2D> borderValue2 = new java.util.ArrayList<java.awt.geom.Point2D>(java.util.Arrays.asList(new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.awt.geom.Point2D> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.awt.geom.Point2D> borderValue3 = new java.util.ArrayList<java.awt.geom.Point2D>(java.util.Arrays.asList(new java.awt.geom.Point2D.Float(), new java.awt.Point(Integer.MIN_VALUE, Integer.MAX_VALUE), new java.awt.Point(-1000000000, 1000000000), new java.awt.geom.Point2D.Float(Float.MIN_VALUE, Float.MAX_VALUE), new java.awt.geom.Point2D.Float(-1.0000001f, 1.0000001f), new java.awt.geom.Point2D.Double(Double.MIN_VALUE, Double.MAX_VALUE), new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.awt.geom.Point2D> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Location/OneLocationDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Location/OneLocationDefaultValueTurtle.java
@@ -1,0 +1,82 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Location;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneLocationDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.awt.geom.Point2D defaultValue = new java.awt.geom.Point2D.Float();
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.awt.geom.Point2D defaultValueJsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.awt.geom.Point2D borderValue1 = new java.awt.Point(Integer.MIN_VALUE, Integer.MAX_VALUE);
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.awt.geom.Point2D borderValue1JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.awt.geom.Point2D borderValue2 = new java.awt.Point(-1000000000, 1000000000);
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.awt.geom.Point2D borderValue2JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.awt.geom.Point2D borderValue3 = new java.awt.geom.Point2D.Float(Float.MIN_VALUE, Float.MAX_VALUE);
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.awt.geom.Point2D borderValue3JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.awt.geom.Point2D borderValue4 = new java.awt.geom.Point2D.Float(-1.0000001f, 1.0000001f);
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.awt.geom.Point2D borderValue4JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.awt.geom.Point2D borderValue5 = new java.awt.geom.Point2D.Double(Double.MIN_VALUE, Double.MAX_VALUE);
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.awt.geom.Point2D borderValue5JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue6Equality() throws IOException {
+        final java.awt.geom.Point2D borderValue6 = new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001);
+        final Bytes borderValue6JsonSerialized = jsonSerialization.serialize(borderValue6);
+        final java.awt.geom.Point2D borderValue6JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Point2D.class, borderValue6JsonSerialized.content, borderValue6JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneEquals(borderValue6, borderValue6JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Location/OneSetOfNullableLocationsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Location/OneSetOfNullableLocationsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Location;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfNullableLocationsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.awt.geom.Point2D> defaultValue = new java.util.HashSet<java.awt.geom.Point2D>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.awt.geom.Point2D> defaultValueJsonDeserialized = new java.util.HashSet<java.awt.geom.Point2D>(jsonSerialization.deserializeList(java.awt.geom.Point2D.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Point2D> borderValue1 = new java.util.HashSet<java.awt.geom.Point2D>(java.util.Arrays.asList((java.awt.geom.Point2D) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.awt.geom.Point2D> borderValue1JsonDeserialized = new java.util.HashSet<java.awt.geom.Point2D>(jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Point2D> borderValue2 = new java.util.HashSet<java.awt.geom.Point2D>(java.util.Arrays.asList(new java.awt.geom.Point2D.Float()));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.awt.geom.Point2D> borderValue2JsonDeserialized = new java.util.HashSet<java.awt.geom.Point2D>(jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Point2D> borderValue3 = new java.util.HashSet<java.awt.geom.Point2D>(java.util.Arrays.asList(new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.awt.geom.Point2D> borderValue3JsonDeserialized = new java.util.HashSet<java.awt.geom.Point2D>(jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Point2D> borderValue4 = new java.util.HashSet<java.awt.geom.Point2D>(java.util.Arrays.asList(new java.awt.geom.Point2D.Float(), new java.awt.Point(Integer.MIN_VALUE, Integer.MAX_VALUE), new java.awt.Point(-1000000000, 1000000000), new java.awt.geom.Point2D.Float(Float.MIN_VALUE, Float.MAX_VALUE), new java.awt.geom.Point2D.Float(-1.0000001f, 1.0000001f), new java.awt.geom.Point2D.Double(Double.MIN_VALUE, Double.MAX_VALUE), new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<java.awt.geom.Point2D> borderValue4JsonDeserialized = new java.util.HashSet<java.awt.geom.Point2D>(jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Point2D> borderValue5 = new java.util.HashSet<java.awt.geom.Point2D>(java.util.Arrays.asList((java.awt.geom.Point2D) null, new java.awt.geom.Point2D.Float(), new java.awt.Point(Integer.MIN_VALUE, Integer.MAX_VALUE), new java.awt.Point(-1000000000, 1000000000), new java.awt.geom.Point2D.Float(Float.MIN_VALUE, Float.MAX_VALUE), new java.awt.geom.Point2D.Float(-1.0000001f, 1.0000001f), new java.awt.geom.Point2D.Double(Double.MIN_VALUE, Double.MAX_VALUE), new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<java.awt.geom.Point2D> borderValue5JsonDeserialized = new java.util.HashSet<java.awt.geom.Point2D>(jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Location/OneSetOfOneLocationsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Location/OneSetOfOneLocationsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Location;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfOneLocationsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.awt.geom.Point2D> defaultValue = new java.util.HashSet<java.awt.geom.Point2D>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.awt.geom.Point2D> defaultValueJsonDeserialized = new java.util.HashSet<java.awt.geom.Point2D>(jsonSerialization.deserializeList(java.awt.geom.Point2D.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Point2D> borderValue1 = new java.util.HashSet<java.awt.geom.Point2D>(java.util.Arrays.asList(new java.awt.geom.Point2D.Float()));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.awt.geom.Point2D> borderValue1JsonDeserialized = new java.util.HashSet<java.awt.geom.Point2D>(jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Point2D> borderValue2 = new java.util.HashSet<java.awt.geom.Point2D>(java.util.Arrays.asList(new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.awt.geom.Point2D> borderValue2JsonDeserialized = new java.util.HashSet<java.awt.geom.Point2D>(jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Point2D> borderValue3 = new java.util.HashSet<java.awt.geom.Point2D>(java.util.Arrays.asList(new java.awt.geom.Point2D.Float(), new java.awt.Point(Integer.MIN_VALUE, Integer.MAX_VALUE), new java.awt.Point(-1000000000, 1000000000), new java.awt.geom.Point2D.Float(Float.MIN_VALUE, Float.MAX_VALUE), new java.awt.geom.Point2D.Float(-1.0000001f, 1.0000001f), new java.awt.geom.Point2D.Double(Double.MIN_VALUE, Double.MAX_VALUE), new java.awt.geom.Point2D.Double(-1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.awt.geom.Point2D> borderValue3JsonDeserialized = new java.util.HashSet<java.awt.geom.Point2D>(jsonSerialization.deserializeList(java.awt.geom.Point2D.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LocationAsserts.assertOneSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Long/NullableArrayOfNullableLongsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Long/NullableArrayOfNullableLongsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Long;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfNullableLongsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final Long[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final Long[] defaultValueJsonDeserialized = jsonSerialization.deserialize(Long[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final Long[] borderValue1 = new Long[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final Long[] borderValue1JsonDeserialized = jsonSerialization.deserialize(Long[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final Long[] borderValue2 = new Long[] { 0L };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final Long[] borderValue2JsonDeserialized = jsonSerialization.deserialize(Long[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final Long[] borderValue3 = new Long[] { Long.MAX_VALUE };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final Long[] borderValue3JsonDeserialized = jsonSerialization.deserialize(Long[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final Long[] borderValue4 = new Long[] { 0L, 1L, 1000000000000000000L, -1000000000000000000L, Long.MIN_VALUE, Long.MAX_VALUE };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final Long[] borderValue4JsonDeserialized = jsonSerialization.deserialize(Long[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final Long[] borderValue5 = new Long[] { null, 0L, 1L, 1000000000000000000L, -1000000000000000000L, Long.MIN_VALUE, Long.MAX_VALUE };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final Long[] borderValue5JsonDeserialized = jsonSerialization.deserialize(Long[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Long/NullableArrayOfOneLongsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Long/NullableArrayOfOneLongsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Long;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfOneLongsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final long[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final long[] defaultValueJsonDeserialized = jsonSerialization.deserialize(long[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final long[] borderValue1 = new long[] { 0L };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final long[] borderValue1JsonDeserialized = jsonSerialization.deserialize(long[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final long[] borderValue2 = new long[] { Long.MAX_VALUE };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final long[] borderValue2JsonDeserialized = jsonSerialization.deserialize(long[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final long[] borderValue3 = new long[] { 0L, 1L, 1000000000000000000L, -1000000000000000000L, Long.MIN_VALUE, Long.MAX_VALUE };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final long[] borderValue3JsonDeserialized = jsonSerialization.deserialize(long[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Long/NullableListOfNullableLongsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Long/NullableListOfNullableLongsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Long;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfNullableLongsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<Long> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<Long> defaultValueJsonDeserialized = jsonSerialization.deserializeList(Long.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<Long> borderValue1 = new java.util.ArrayList<Long>(java.util.Arrays.asList((Long) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<Long> borderValue1JsonDeserialized = jsonSerialization.deserializeList(Long.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<Long> borderValue2 = new java.util.ArrayList<Long>(java.util.Arrays.asList(0L));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<Long> borderValue2JsonDeserialized = jsonSerialization.deserializeList(Long.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<Long> borderValue3 = new java.util.ArrayList<Long>(java.util.Arrays.asList(Long.MAX_VALUE));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<Long> borderValue3JsonDeserialized = jsonSerialization.deserializeList(Long.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<Long> borderValue4 = new java.util.ArrayList<Long>(java.util.Arrays.asList(0L, 1L, 1000000000000000000L, -1000000000000000000L, Long.MIN_VALUE, Long.MAX_VALUE));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<Long> borderValue4JsonDeserialized = jsonSerialization.deserializeList(Long.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<Long> borderValue5 = new java.util.ArrayList<Long>(java.util.Arrays.asList((Long) null, 0L, 1L, 1000000000000000000L, -1000000000000000000L, Long.MIN_VALUE, Long.MAX_VALUE));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<Long> borderValue5JsonDeserialized = jsonSerialization.deserializeList(Long.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Long/NullableListOfOneLongsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Long/NullableListOfOneLongsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Long;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfOneLongsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<Long> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<Long> defaultValueJsonDeserialized = jsonSerialization.deserializeList(Long.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<Long> borderValue1 = new java.util.ArrayList<Long>(java.util.Arrays.asList(0L));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<Long> borderValue1JsonDeserialized = jsonSerialization.deserializeList(Long.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<Long> borderValue2 = new java.util.ArrayList<Long>(java.util.Arrays.asList(Long.MAX_VALUE));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<Long> borderValue2JsonDeserialized = jsonSerialization.deserializeList(Long.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<Long> borderValue3 = new java.util.ArrayList<Long>(java.util.Arrays.asList(0L, 1L, 1000000000000000000L, -1000000000000000000L, Long.MIN_VALUE, Long.MAX_VALUE));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<Long> borderValue3JsonDeserialized = jsonSerialization.deserializeList(Long.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Long/NullableLongDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Long/NullableLongDefaultValueTurtle.java
@@ -1,0 +1,82 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Long;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableLongDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final Long defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final Long defaultValueJsonDeserialized = jsonSerialization.deserialize(Long.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final Long borderValue1 = 0L;
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final Long borderValue1JsonDeserialized = jsonSerialization.deserialize(Long.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final Long borderValue2 = 1L;
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final Long borderValue2JsonDeserialized = jsonSerialization.deserialize(Long.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final Long borderValue3 = 1000000000000000000L;
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final Long borderValue3JsonDeserialized = jsonSerialization.deserialize(Long.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final Long borderValue4 = -1000000000000000000L;
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final Long borderValue4JsonDeserialized = jsonSerialization.deserialize(Long.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final Long borderValue5 = Long.MIN_VALUE;
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final Long borderValue5JsonDeserialized = jsonSerialization.deserialize(Long.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue6Equality() throws IOException {
+        final Long borderValue6 = Long.MAX_VALUE;
+        final Bytes borderValue6JsonSerialized = jsonSerialization.serialize(borderValue6);
+        final Long borderValue6JsonDeserialized = jsonSerialization.deserialize(Long.class, borderValue6JsonSerialized.content, borderValue6JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableEquals(borderValue6, borderValue6JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Long/NullableSetOfNullableLongsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Long/NullableSetOfNullableLongsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Long;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfNullableLongsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<Long> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<Long> defaultValueJsonDeserialized = new java.util.HashSet<Long>(jsonSerialization.deserializeList(Long.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<Long> borderValue1 = new java.util.HashSet<Long>(java.util.Arrays.asList((Long) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<Long> borderValue1JsonDeserialized = new java.util.HashSet<Long>(jsonSerialization.deserializeList(Long.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<Long> borderValue2 = new java.util.HashSet<Long>(java.util.Arrays.asList(0L));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<Long> borderValue2JsonDeserialized = new java.util.HashSet<Long>(jsonSerialization.deserializeList(Long.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<Long> borderValue3 = new java.util.HashSet<Long>(java.util.Arrays.asList(Long.MAX_VALUE));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<Long> borderValue3JsonDeserialized = new java.util.HashSet<Long>(jsonSerialization.deserializeList(Long.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<Long> borderValue4 = new java.util.HashSet<Long>(java.util.Arrays.asList(0L, 1L, 1000000000000000000L, -1000000000000000000L, Long.MIN_VALUE, Long.MAX_VALUE));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<Long> borderValue4JsonDeserialized = new java.util.HashSet<Long>(jsonSerialization.deserializeList(Long.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<Long> borderValue5 = new java.util.HashSet<Long>(java.util.Arrays.asList((Long) null, 0L, 1L, 1000000000000000000L, -1000000000000000000L, Long.MIN_VALUE, Long.MAX_VALUE));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<Long> borderValue5JsonDeserialized = new java.util.HashSet<Long>(jsonSerialization.deserializeList(Long.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Long/NullableSetOfOneLongsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Long/NullableSetOfOneLongsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Long;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfOneLongsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<Long> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<Long> defaultValueJsonDeserialized = new java.util.HashSet<Long>(jsonSerialization.deserializeList(Long.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<Long> borderValue1 = new java.util.HashSet<Long>(java.util.Arrays.asList(0L));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<Long> borderValue1JsonDeserialized = new java.util.HashSet<Long>(jsonSerialization.deserializeList(Long.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<Long> borderValue2 = new java.util.HashSet<Long>(java.util.Arrays.asList(Long.MAX_VALUE));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<Long> borderValue2JsonDeserialized = new java.util.HashSet<Long>(jsonSerialization.deserializeList(Long.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<Long> borderValue3 = new java.util.HashSet<Long>(java.util.Arrays.asList(0L, 1L, 1000000000000000000L, -1000000000000000000L, Long.MIN_VALUE, Long.MAX_VALUE));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<Long> borderValue3JsonDeserialized = new java.util.HashSet<Long>(jsonSerialization.deserializeList(Long.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertNullableSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Long/OneArrayOfNullableLongsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Long/OneArrayOfNullableLongsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Long;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfNullableLongsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final Long[] defaultValue = new Long[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final Long[] defaultValueJsonDeserialized = jsonSerialization.deserialize(Long[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final Long[] borderValue1 = new Long[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final Long[] borderValue1JsonDeserialized = jsonSerialization.deserialize(Long[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final Long[] borderValue2 = new Long[] { 0L };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final Long[] borderValue2JsonDeserialized = jsonSerialization.deserialize(Long[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final Long[] borderValue3 = new Long[] { Long.MAX_VALUE };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final Long[] borderValue3JsonDeserialized = jsonSerialization.deserialize(Long[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final Long[] borderValue4 = new Long[] { 0L, 1L, 1000000000000000000L, -1000000000000000000L, Long.MIN_VALUE, Long.MAX_VALUE };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final Long[] borderValue4JsonDeserialized = jsonSerialization.deserialize(Long[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final Long[] borderValue5 = new Long[] { null, 0L, 1L, 1000000000000000000L, -1000000000000000000L, Long.MIN_VALUE, Long.MAX_VALUE };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final Long[] borderValue5JsonDeserialized = jsonSerialization.deserialize(Long[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Long/OneArrayOfOneLongsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Long/OneArrayOfOneLongsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Long;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfOneLongsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final long[] defaultValue = new long[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final long[] defaultValueJsonDeserialized = jsonSerialization.deserialize(long[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final long[] borderValue1 = new long[] { 0L };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final long[] borderValue1JsonDeserialized = jsonSerialization.deserialize(long[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final long[] borderValue2 = new long[] { Long.MAX_VALUE };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final long[] borderValue2JsonDeserialized = jsonSerialization.deserialize(long[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final long[] borderValue3 = new long[] { 0L, 1L, 1000000000000000000L, -1000000000000000000L, Long.MIN_VALUE, Long.MAX_VALUE };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final long[] borderValue3JsonDeserialized = jsonSerialization.deserialize(long[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Long/OneListOfNullableLongsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Long/OneListOfNullableLongsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Long;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfNullableLongsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<Long> defaultValue = new java.util.ArrayList<Long>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<Long> defaultValueJsonDeserialized = jsonSerialization.deserializeList(Long.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<Long> borderValue1 = new java.util.ArrayList<Long>(java.util.Arrays.asList((Long) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<Long> borderValue1JsonDeserialized = jsonSerialization.deserializeList(Long.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<Long> borderValue2 = new java.util.ArrayList<Long>(java.util.Arrays.asList(0L));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<Long> borderValue2JsonDeserialized = jsonSerialization.deserializeList(Long.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<Long> borderValue3 = new java.util.ArrayList<Long>(java.util.Arrays.asList(Long.MAX_VALUE));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<Long> borderValue3JsonDeserialized = jsonSerialization.deserializeList(Long.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<Long> borderValue4 = new java.util.ArrayList<Long>(java.util.Arrays.asList(0L, 1L, 1000000000000000000L, -1000000000000000000L, Long.MIN_VALUE, Long.MAX_VALUE));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<Long> borderValue4JsonDeserialized = jsonSerialization.deserializeList(Long.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<Long> borderValue5 = new java.util.ArrayList<Long>(java.util.Arrays.asList((Long) null, 0L, 1L, 1000000000000000000L, -1000000000000000000L, Long.MIN_VALUE, Long.MAX_VALUE));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<Long> borderValue5JsonDeserialized = jsonSerialization.deserializeList(Long.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Long/OneListOfOneLongsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Long/OneListOfOneLongsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Long;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfOneLongsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<Long> defaultValue = new java.util.ArrayList<Long>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<Long> defaultValueJsonDeserialized = jsonSerialization.deserializeList(Long.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<Long> borderValue1 = new java.util.ArrayList<Long>(java.util.Arrays.asList(0L));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<Long> borderValue1JsonDeserialized = jsonSerialization.deserializeList(Long.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<Long> borderValue2 = new java.util.ArrayList<Long>(java.util.Arrays.asList(Long.MAX_VALUE));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<Long> borderValue2JsonDeserialized = jsonSerialization.deserializeList(Long.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<Long> borderValue3 = new java.util.ArrayList<Long>(java.util.Arrays.asList(0L, 1L, 1000000000000000000L, -1000000000000000000L, Long.MIN_VALUE, Long.MAX_VALUE));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<Long> borderValue3JsonDeserialized = jsonSerialization.deserializeList(Long.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Long/OneLongDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Long/OneLongDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Long;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneLongDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final long defaultValue = 0L;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final long defaultValueJsonDeserialized = jsonSerialization.deserialize(long.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final long borderValue1 = 1L;
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final long borderValue1JsonDeserialized = jsonSerialization.deserialize(long.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final long borderValue2 = 1000000000000000000L;
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final long borderValue2JsonDeserialized = jsonSerialization.deserialize(long.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final long borderValue3 = -1000000000000000000L;
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final long borderValue3JsonDeserialized = jsonSerialization.deserialize(long.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final long borderValue4 = Long.MIN_VALUE;
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final long borderValue4JsonDeserialized = jsonSerialization.deserialize(long.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final long borderValue5 = Long.MAX_VALUE;
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final long borderValue5JsonDeserialized = jsonSerialization.deserialize(long.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Long/OneSetOfNullableLongsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Long/OneSetOfNullableLongsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Long;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfNullableLongsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<Long> defaultValue = new java.util.HashSet<Long>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<Long> defaultValueJsonDeserialized = new java.util.HashSet<Long>(jsonSerialization.deserializeList(Long.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<Long> borderValue1 = new java.util.HashSet<Long>(java.util.Arrays.asList((Long) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<Long> borderValue1JsonDeserialized = new java.util.HashSet<Long>(jsonSerialization.deserializeList(Long.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<Long> borderValue2 = new java.util.HashSet<Long>(java.util.Arrays.asList(0L));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<Long> borderValue2JsonDeserialized = new java.util.HashSet<Long>(jsonSerialization.deserializeList(Long.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<Long> borderValue3 = new java.util.HashSet<Long>(java.util.Arrays.asList(Long.MAX_VALUE));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<Long> borderValue3JsonDeserialized = new java.util.HashSet<Long>(jsonSerialization.deserializeList(Long.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<Long> borderValue4 = new java.util.HashSet<Long>(java.util.Arrays.asList(0L, 1L, 1000000000000000000L, -1000000000000000000L, Long.MIN_VALUE, Long.MAX_VALUE));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<Long> borderValue4JsonDeserialized = new java.util.HashSet<Long>(jsonSerialization.deserializeList(Long.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<Long> borderValue5 = new java.util.HashSet<Long>(java.util.Arrays.asList((Long) null, 0L, 1L, 1000000000000000000L, -1000000000000000000L, Long.MIN_VALUE, Long.MAX_VALUE));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<Long> borderValue5JsonDeserialized = new java.util.HashSet<Long>(jsonSerialization.deserializeList(Long.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Long/OneSetOfOneLongsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Long/OneSetOfOneLongsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Long;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfOneLongsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<Long> defaultValue = new java.util.HashSet<Long>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<Long> defaultValueJsonDeserialized = new java.util.HashSet<Long>(jsonSerialization.deserializeList(Long.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<Long> borderValue1 = new java.util.HashSet<Long>(java.util.Arrays.asList(0L));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<Long> borderValue1JsonDeserialized = new java.util.HashSet<Long>(jsonSerialization.deserializeList(Long.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<Long> borderValue2 = new java.util.HashSet<Long>(java.util.Arrays.asList(Long.MAX_VALUE));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<Long> borderValue2JsonDeserialized = new java.util.HashSet<Long>(jsonSerialization.deserializeList(Long.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<Long> borderValue3 = new java.util.HashSet<Long>(java.util.Arrays.asList(0L, 1L, 1000000000000000000L, -1000000000000000000L, Long.MIN_VALUE, Long.MAX_VALUE));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<Long> borderValue3JsonDeserialized = new java.util.HashSet<Long>(jsonSerialization.deserializeList(Long.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.LongAsserts.assertOneSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Map/NullableArrayOfNullableMapsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Map/NullableArrayOfNullableMapsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Map;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfNullableMapsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Map<String, String>[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Map<String, String>[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.util.Map[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Map<String, String>[] borderValue1 = new java.util.Map[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Map<String, String>[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.util.Map[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Map<String, String>[] borderValue2 = new java.util.Map[] { new java.util.HashMap<String, String>(0) };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Map<String, String>[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.util.Map[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Map<String, String>[] borderValue3 = new java.util.Map[] { new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }} };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Map<String, String>[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.util.Map[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Map<String, String>[] borderValue4 = new java.util.Map[] { new java.util.HashMap<String, String>(0), new java.util.HashMap<String, String>() {{ put("a", "b"); }}, new java.util.HashMap<String, String>() {{ put("Quote: \", Solidus /", "Backslash: \\, Aphos: ', Brackets: [] () {}"); }}, new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }} };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Map<String, String>[] borderValue4JsonDeserialized = jsonSerialization.deserialize(java.util.Map[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Map<String, String>[] borderValue5 = new java.util.Map[] { null, new java.util.HashMap<String, String>(0), new java.util.HashMap<String, String>() {{ put("a", "b"); }}, new java.util.HashMap<String, String>() {{ put("Quote: \", Solidus /", "Backslash: \\, Aphos: ', Brackets: [] () {}"); }}, new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }} };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Map<String, String>[] borderValue5JsonDeserialized = jsonSerialization.deserialize(java.util.Map[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Map/NullableArrayOfOneMapsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Map/NullableArrayOfOneMapsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Map;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfOneMapsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Map<String, String>[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Map<String, String>[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.util.Map[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Map<String, String>[] borderValue1 = new java.util.Map[] { new java.util.HashMap<String, String>(0) };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Map<String, String>[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.util.Map[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Map<String, String>[] borderValue2 = new java.util.Map[] { new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }} };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Map<String, String>[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.util.Map[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Map<String, String>[] borderValue3 = new java.util.Map[] { new java.util.HashMap<String, String>(0), new java.util.HashMap<String, String>() {{ put("a", "b"); }}, new java.util.HashMap<String, String>() {{ put("Quote: \", Solidus /", "Backslash: \\, Aphos: ', Brackets: [] () {}"); }}, new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }} };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Map<String, String>[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.util.Map[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Map/NullableListOfNullableMapsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Map/NullableListOfNullableMapsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Map;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfNullableMapsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.util.Map<String, String>> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.util.Map<String, String>> defaultValueJsonDeserialized = (java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.util.Map<String, String>> borderValue1 = new java.util.ArrayList<java.util.Map<String, String>>(java.util.Arrays.asList((java.util.Map<String, String>) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.util.Map<String, String>> borderValue1JsonDeserialized = (java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.util.Map<String, String>> borderValue2 = new java.util.ArrayList<java.util.Map<String, String>>(java.util.Arrays.asList(new java.util.HashMap<String, String>(0)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.util.Map<String, String>> borderValue2JsonDeserialized = (java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.util.Map<String, String>> borderValue3 = new java.util.ArrayList<java.util.Map<String, String>>(java.util.Arrays.asList(new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }}));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.util.Map<String, String>> borderValue3JsonDeserialized = (java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<java.util.Map<String, String>> borderValue4 = new java.util.ArrayList<java.util.Map<String, String>>(java.util.Arrays.asList(new java.util.HashMap<String, String>(0), new java.util.HashMap<String, String>() {{ put("a", "b"); }}, new java.util.HashMap<String, String>() {{ put("Quote: \", Solidus /", "Backslash: \\, Aphos: ', Brackets: [] () {}"); }}, new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }}));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<java.util.Map<String, String>> borderValue4JsonDeserialized = (java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<java.util.Map<String, String>> borderValue5 = new java.util.ArrayList<java.util.Map<String, String>>(java.util.Arrays.asList((java.util.Map<String, String>) null, new java.util.HashMap<String, String>(0), new java.util.HashMap<String, String>() {{ put("a", "b"); }}, new java.util.HashMap<String, String>() {{ put("Quote: \", Solidus /", "Backslash: \\, Aphos: ', Brackets: [] () {}"); }}, new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }}));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<java.util.Map<String, String>> borderValue5JsonDeserialized = (java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Map/NullableListOfOneMapsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Map/NullableListOfOneMapsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Map;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfOneMapsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.util.Map<String, String>> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.util.Map<String, String>> defaultValueJsonDeserialized = (java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.util.Map<String, String>> borderValue1 = new java.util.ArrayList<java.util.Map<String, String>>(java.util.Arrays.asList(new java.util.HashMap<String, String>(0)));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.util.Map<String, String>> borderValue1JsonDeserialized = (java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.util.Map<String, String>> borderValue2 = new java.util.ArrayList<java.util.Map<String, String>>(java.util.Arrays.asList(new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }}));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.util.Map<String, String>> borderValue2JsonDeserialized = (java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.util.Map<String, String>> borderValue3 = new java.util.ArrayList<java.util.Map<String, String>>(java.util.Arrays.asList(new java.util.HashMap<String, String>(0), new java.util.HashMap<String, String>() {{ put("a", "b"); }}, new java.util.HashMap<String, String>() {{ put("Quote: \", Solidus /", "Backslash: \\, Aphos: ', Brackets: [] () {}"); }}, new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }}));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.util.Map<String, String>> borderValue3JsonDeserialized = (java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Map/NullableMapDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Map/NullableMapDefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Map;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableMapDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Map<String, String> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Map<String, String> defaultValueJsonDeserialized = (java.util.Map<String, String>) jsonSerialization.deserialize(java.util.Map.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Map<String, String> borderValue1 = new java.util.HashMap<String, String>(0);
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Map<String, String> borderValue1JsonDeserialized = (java.util.Map<String, String>) jsonSerialization.deserialize(java.util.Map.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Map<String, String> borderValue2 = new java.util.HashMap<String, String>() {{ put("a", "b"); }};
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Map<String, String> borderValue2JsonDeserialized = (java.util.Map<String, String>) jsonSerialization.deserialize(java.util.Map.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Map<String, String> borderValue3 = new java.util.HashMap<String, String>() {{ put("Quote: \", Solidus /", "Backslash: \\, Aphos: ', Brackets: [] () {}"); }};
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Map<String, String> borderValue3JsonDeserialized = (java.util.Map<String, String>) jsonSerialization.deserialize(java.util.Map.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Map<String, String> borderValue4 = new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }};
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Map<String, String> borderValue4JsonDeserialized = (java.util.Map<String, String>) jsonSerialization.deserialize(java.util.Map.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Map/NullableSetOfNullableMapsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Map/NullableSetOfNullableMapsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Map;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfNullableMapsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.util.Map<String, String>> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.util.Map<String, String>> defaultValueJsonDeserialized = new java.util.HashSet<java.util.Map<String, String>>((java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.util.Map<String, String>> borderValue1 = new java.util.HashSet<java.util.Map<String, String>>(java.util.Arrays.asList((java.util.Map<String, String>) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.util.Map<String, String>> borderValue1JsonDeserialized = new java.util.HashSet<java.util.Map<String, String>>((java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.util.Map<String, String>> borderValue2 = new java.util.HashSet<java.util.Map<String, String>>(java.util.Arrays.asList(new java.util.HashMap<String, String>(0)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.util.Map<String, String>> borderValue2JsonDeserialized = new java.util.HashSet<java.util.Map<String, String>>((java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.util.Map<String, String>> borderValue3 = new java.util.HashSet<java.util.Map<String, String>>(java.util.Arrays.asList(new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }}));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.util.Map<String, String>> borderValue3JsonDeserialized = new java.util.HashSet<java.util.Map<String, String>>((java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<java.util.Map<String, String>> borderValue4 = new java.util.HashSet<java.util.Map<String, String>>(java.util.Arrays.asList(new java.util.HashMap<String, String>(0), new java.util.HashMap<String, String>() {{ put("a", "b"); }}, new java.util.HashMap<String, String>() {{ put("Quote: \", Solidus /", "Backslash: \\, Aphos: ', Brackets: [] () {}"); }}, new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }}));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<java.util.Map<String, String>> borderValue4JsonDeserialized = new java.util.HashSet<java.util.Map<String, String>>((java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<java.util.Map<String, String>> borderValue5 = new java.util.HashSet<java.util.Map<String, String>>(java.util.Arrays.asList((java.util.Map<String, String>) null, new java.util.HashMap<String, String>(0), new java.util.HashMap<String, String>() {{ put("a", "b"); }}, new java.util.HashMap<String, String>() {{ put("Quote: \", Solidus /", "Backslash: \\, Aphos: ', Brackets: [] () {}"); }}, new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }}));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<java.util.Map<String, String>> borderValue5JsonDeserialized = new java.util.HashSet<java.util.Map<String, String>>((java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Map/NullableSetOfOneMapsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Map/NullableSetOfOneMapsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Map;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfOneMapsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.util.Map<String, String>> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.util.Map<String, String>> defaultValueJsonDeserialized = new java.util.HashSet<java.util.Map<String, String>>((java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.util.Map<String, String>> borderValue1 = new java.util.HashSet<java.util.Map<String, String>>(java.util.Arrays.asList(new java.util.HashMap<String, String>(0)));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.util.Map<String, String>> borderValue1JsonDeserialized = new java.util.HashSet<java.util.Map<String, String>>((java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.util.Map<String, String>> borderValue2 = new java.util.HashSet<java.util.Map<String, String>>(java.util.Arrays.asList(new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }}));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.util.Map<String, String>> borderValue2JsonDeserialized = new java.util.HashSet<java.util.Map<String, String>>((java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.util.Map<String, String>> borderValue3 = new java.util.HashSet<java.util.Map<String, String>>(java.util.Arrays.asList(new java.util.HashMap<String, String>(0), new java.util.HashMap<String, String>() {{ put("a", "b"); }}, new java.util.HashMap<String, String>() {{ put("Quote: \", Solidus /", "Backslash: \\, Aphos: ', Brackets: [] () {}"); }}, new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }}));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.util.Map<String, String>> borderValue3JsonDeserialized = new java.util.HashSet<java.util.Map<String, String>>((java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertNullableSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Map/OneArrayOfNullableMapsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Map/OneArrayOfNullableMapsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Map;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfNullableMapsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Map<String, String>[] defaultValue = new java.util.Map[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Map<String, String>[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.util.Map[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Map<String, String>[] borderValue1 = new java.util.Map[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Map<String, String>[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.util.Map[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Map<String, String>[] borderValue2 = new java.util.Map[] { new java.util.HashMap<String, String>(0) };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Map<String, String>[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.util.Map[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Map<String, String>[] borderValue3 = new java.util.Map[] { new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }} };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Map<String, String>[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.util.Map[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Map<String, String>[] borderValue4 = new java.util.Map[] { new java.util.HashMap<String, String>(0), new java.util.HashMap<String, String>() {{ put("a", "b"); }}, new java.util.HashMap<String, String>() {{ put("Quote: \", Solidus /", "Backslash: \\, Aphos: ', Brackets: [] () {}"); }}, new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }} };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Map<String, String>[] borderValue4JsonDeserialized = jsonSerialization.deserialize(java.util.Map[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Map<String, String>[] borderValue5 = new java.util.Map[] { null, new java.util.HashMap<String, String>(0), new java.util.HashMap<String, String>() {{ put("a", "b"); }}, new java.util.HashMap<String, String>() {{ put("Quote: \", Solidus /", "Backslash: \\, Aphos: ', Brackets: [] () {}"); }}, new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }} };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Map<String, String>[] borderValue5JsonDeserialized = jsonSerialization.deserialize(java.util.Map[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Map/OneArrayOfOneMapsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Map/OneArrayOfOneMapsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Map;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfOneMapsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Map<String, String>[] defaultValue = new java.util.Map[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Map<String, String>[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.util.Map[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Map<String, String>[] borderValue1 = new java.util.Map[] { new java.util.HashMap<String, String>(0) };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Map<String, String>[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.util.Map[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Map<String, String>[] borderValue2 = new java.util.Map[] { new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }} };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Map<String, String>[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.util.Map[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Map<String, String>[] borderValue3 = new java.util.Map[] { new java.util.HashMap<String, String>(0), new java.util.HashMap<String, String>() {{ put("a", "b"); }}, new java.util.HashMap<String, String>() {{ put("Quote: \", Solidus /", "Backslash: \\, Aphos: ', Brackets: [] () {}"); }}, new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }} };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Map<String, String>[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.util.Map[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Map/OneListOfNullableMapsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Map/OneListOfNullableMapsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Map;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfNullableMapsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.util.Map<String, String>> defaultValue = new java.util.ArrayList<java.util.Map<String, String>>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.util.Map<String, String>> defaultValueJsonDeserialized = (java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.util.Map<String, String>> borderValue1 = new java.util.ArrayList<java.util.Map<String, String>>(java.util.Arrays.asList((java.util.Map<String, String>) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.util.Map<String, String>> borderValue1JsonDeserialized = (java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.util.Map<String, String>> borderValue2 = new java.util.ArrayList<java.util.Map<String, String>>(java.util.Arrays.asList(new java.util.HashMap<String, String>(0)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.util.Map<String, String>> borderValue2JsonDeserialized = (java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.util.Map<String, String>> borderValue3 = new java.util.ArrayList<java.util.Map<String, String>>(java.util.Arrays.asList(new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }}));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.util.Map<String, String>> borderValue3JsonDeserialized = (java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<java.util.Map<String, String>> borderValue4 = new java.util.ArrayList<java.util.Map<String, String>>(java.util.Arrays.asList(new java.util.HashMap<String, String>(0), new java.util.HashMap<String, String>() {{ put("a", "b"); }}, new java.util.HashMap<String, String>() {{ put("Quote: \", Solidus /", "Backslash: \\, Aphos: ', Brackets: [] () {}"); }}, new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }}));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<java.util.Map<String, String>> borderValue4JsonDeserialized = (java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<java.util.Map<String, String>> borderValue5 = new java.util.ArrayList<java.util.Map<String, String>>(java.util.Arrays.asList((java.util.Map<String, String>) null, new java.util.HashMap<String, String>(0), new java.util.HashMap<String, String>() {{ put("a", "b"); }}, new java.util.HashMap<String, String>() {{ put("Quote: \", Solidus /", "Backslash: \\, Aphos: ', Brackets: [] () {}"); }}, new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }}));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<java.util.Map<String, String>> borderValue5JsonDeserialized = (java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Map/OneListOfOneMapsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Map/OneListOfOneMapsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Map;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfOneMapsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.util.Map<String, String>> defaultValue = new java.util.ArrayList<java.util.Map<String, String>>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.util.Map<String, String>> defaultValueJsonDeserialized = (java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.util.Map<String, String>> borderValue1 = new java.util.ArrayList<java.util.Map<String, String>>(java.util.Arrays.asList(new java.util.HashMap<String, String>(0)));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.util.Map<String, String>> borderValue1JsonDeserialized = (java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.util.Map<String, String>> borderValue2 = new java.util.ArrayList<java.util.Map<String, String>>(java.util.Arrays.asList(new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }}));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.util.Map<String, String>> borderValue2JsonDeserialized = (java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.util.Map<String, String>> borderValue3 = new java.util.ArrayList<java.util.Map<String, String>>(java.util.Arrays.asList(new java.util.HashMap<String, String>(0), new java.util.HashMap<String, String>() {{ put("a", "b"); }}, new java.util.HashMap<String, String>() {{ put("Quote: \", Solidus /", "Backslash: \\, Aphos: ', Brackets: [] () {}"); }}, new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }}));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.util.Map<String, String>> borderValue3JsonDeserialized = (java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Map/OneMapDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Map/OneMapDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Map;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneMapDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Map<String, String> defaultValue = new java.util.HashMap<String, String>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Map<String, String> defaultValueJsonDeserialized = (java.util.Map<String, String>) jsonSerialization.deserialize(java.util.Map.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Map<String, String> borderValue1 = new java.util.HashMap<String, String>() {{ put("a", "b"); }};
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Map<String, String> borderValue1JsonDeserialized = (java.util.Map<String, String>) jsonSerialization.deserialize(java.util.Map.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Map<String, String> borderValue2 = new java.util.HashMap<String, String>() {{ put("Quote: \", Solidus /", "Backslash: \\, Aphos: ', Brackets: [] () {}"); }};
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Map<String, String> borderValue2JsonDeserialized = (java.util.Map<String, String>) jsonSerialization.deserialize(java.util.Map.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Map<String, String> borderValue3 = new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }};
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Map<String, String> borderValue3JsonDeserialized = (java.util.Map<String, String>) jsonSerialization.deserialize(java.util.Map.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Map/OneSetOfNullableMapsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Map/OneSetOfNullableMapsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Map;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfNullableMapsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.util.Map<String, String>> defaultValue = new java.util.HashSet<java.util.Map<String, String>>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.util.Map<String, String>> defaultValueJsonDeserialized = new java.util.HashSet<java.util.Map<String, String>>((java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.util.Map<String, String>> borderValue1 = new java.util.HashSet<java.util.Map<String, String>>(java.util.Arrays.asList((java.util.Map<String, String>) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.util.Map<String, String>> borderValue1JsonDeserialized = new java.util.HashSet<java.util.Map<String, String>>((java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.util.Map<String, String>> borderValue2 = new java.util.HashSet<java.util.Map<String, String>>(java.util.Arrays.asList(new java.util.HashMap<String, String>(0)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.util.Map<String, String>> borderValue2JsonDeserialized = new java.util.HashSet<java.util.Map<String, String>>((java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.util.Map<String, String>> borderValue3 = new java.util.HashSet<java.util.Map<String, String>>(java.util.Arrays.asList(new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }}));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.util.Map<String, String>> borderValue3JsonDeserialized = new java.util.HashSet<java.util.Map<String, String>>((java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<java.util.Map<String, String>> borderValue4 = new java.util.HashSet<java.util.Map<String, String>>(java.util.Arrays.asList(new java.util.HashMap<String, String>(0), new java.util.HashMap<String, String>() {{ put("a", "b"); }}, new java.util.HashMap<String, String>() {{ put("Quote: \", Solidus /", "Backslash: \\, Aphos: ', Brackets: [] () {}"); }}, new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }}));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<java.util.Map<String, String>> borderValue4JsonDeserialized = new java.util.HashSet<java.util.Map<String, String>>((java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<java.util.Map<String, String>> borderValue5 = new java.util.HashSet<java.util.Map<String, String>>(java.util.Arrays.asList((java.util.Map<String, String>) null, new java.util.HashMap<String, String>(0), new java.util.HashMap<String, String>() {{ put("a", "b"); }}, new java.util.HashMap<String, String>() {{ put("Quote: \", Solidus /", "Backslash: \\, Aphos: ', Brackets: [] () {}"); }}, new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }}));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<java.util.Map<String, String>> borderValue5JsonDeserialized = new java.util.HashSet<java.util.Map<String, String>>((java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Map/OneSetOfOneMapsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Map/OneSetOfOneMapsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Map;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfOneMapsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.util.Map<String, String>> defaultValue = new java.util.HashSet<java.util.Map<String, String>>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.util.Map<String, String>> defaultValueJsonDeserialized = new java.util.HashSet<java.util.Map<String, String>>((java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.util.Map<String, String>> borderValue1 = new java.util.HashSet<java.util.Map<String, String>>(java.util.Arrays.asList(new java.util.HashMap<String, String>(0)));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.util.Map<String, String>> borderValue1JsonDeserialized = new java.util.HashSet<java.util.Map<String, String>>((java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.util.Map<String, String>> borderValue2 = new java.util.HashSet<java.util.Map<String, String>>(java.util.Arrays.asList(new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }}));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.util.Map<String, String>> borderValue2JsonDeserialized = new java.util.HashSet<java.util.Map<String, String>>((java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.util.Map<String, String>> borderValue3 = new java.util.HashSet<java.util.Map<String, String>>(java.util.Arrays.asList(new java.util.HashMap<String, String>(0), new java.util.HashMap<String, String>() {{ put("a", "b"); }}, new java.util.HashMap<String, String>() {{ put("Quote: \", Solidus /", "Backslash: \\, Aphos: ', Brackets: [] () {}"); }}, new java.util.HashMap<String, String>() {{ put("", "empty"); put("a", "1"); put("b", "2"); put("c", "3"); }}));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.util.Map<String, String>> borderValue3JsonDeserialized = new java.util.HashSet<java.util.Map<String, String>>((java.util.List<java.util.Map<String, String>>) (java.util.List<?>) jsonSerialization.deserialize(java.util.Map.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MapAsserts.assertOneSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Money/NullableArrayOfNullableMoniesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Money/NullableArrayOfNullableMoniesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Money;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfNullableMoniesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.math.BigDecimal[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.math.BigDecimal[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue1 = new java.math.BigDecimal[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.math.BigDecimal[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue2 = new java.math.BigDecimal[] { java.math.BigDecimal.ZERO.setScale(2) };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.math.BigDecimal[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue3 = new java.math.BigDecimal[] { new java.math.BigDecimal("1E19") };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.math.BigDecimal[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue4 = new java.math.BigDecimal[] { java.math.BigDecimal.ZERO.setScale(2), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(2, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-2"), new java.math.BigDecimal("1E19") };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.math.BigDecimal[] borderValue4JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue5 = new java.math.BigDecimal[] { null, java.math.BigDecimal.ZERO.setScale(2), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(2, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-2"), new java.math.BigDecimal("1E19") };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.math.BigDecimal[] borderValue5JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Money/NullableArrayOfOneMoniesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Money/NullableArrayOfOneMoniesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Money;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfOneMoniesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.math.BigDecimal[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.math.BigDecimal[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue1 = new java.math.BigDecimal[] { java.math.BigDecimal.ZERO.setScale(2) };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.math.BigDecimal[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue2 = new java.math.BigDecimal[] { new java.math.BigDecimal("1E19") };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.math.BigDecimal[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue3 = new java.math.BigDecimal[] { java.math.BigDecimal.ZERO.setScale(2), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(2, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-2"), new java.math.BigDecimal("1E19") };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.math.BigDecimal[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Money/NullableListOfNullableMoniesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Money/NullableListOfNullableMoniesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Money;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfNullableMoniesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.math.BigDecimal> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.math.BigDecimal> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue1 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList((java.math.BigDecimal) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.math.BigDecimal> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue2 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(2)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.math.BigDecimal> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue3 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(new java.math.BigDecimal("1E19")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.math.BigDecimal> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue4 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(2), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(2, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-2"), new java.math.BigDecimal("1E19")));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<java.math.BigDecimal> borderValue4JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue5 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList((java.math.BigDecimal) null, java.math.BigDecimal.ZERO.setScale(2), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(2, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-2"), new java.math.BigDecimal("1E19")));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<java.math.BigDecimal> borderValue5JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Money/NullableListOfOneMoniesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Money/NullableListOfOneMoniesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Money;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfOneMoniesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.math.BigDecimal> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.math.BigDecimal> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue1 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(2)));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.math.BigDecimal> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue2 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(new java.math.BigDecimal("1E19")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.math.BigDecimal> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue3 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(2), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(2, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-2"), new java.math.BigDecimal("1E19")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.math.BigDecimal> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Money/NullableMoneyDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Money/NullableMoneyDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Money;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableMoneyDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.math.BigDecimal defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.math.BigDecimal defaultValueJsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.math.BigDecimal borderValue1 = java.math.BigDecimal.ZERO.setScale(2);
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.math.BigDecimal borderValue1JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.math.BigDecimal borderValue2 = java.math.BigDecimal.ONE;
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.math.BigDecimal borderValue2JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.math.BigDecimal borderValue3 = new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(2, java.math.BigDecimal.ROUND_HALF_UP);
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.math.BigDecimal borderValue3JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.math.BigDecimal borderValue4 = new java.math.BigDecimal("-1E-2");
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.math.BigDecimal borderValue4JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.math.BigDecimal borderValue5 = new java.math.BigDecimal("1E19");
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.math.BigDecimal borderValue5JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Money/NullableSetOfNullableMoniesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Money/NullableSetOfNullableMoniesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Money;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfNullableMoniesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.math.BigDecimal> defaultValueJsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue1 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList((java.math.BigDecimal) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.math.BigDecimal> borderValue1JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue2 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(2)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.math.BigDecimal> borderValue2JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue3 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(new java.math.BigDecimal("1E19")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.math.BigDecimal> borderValue3JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue4 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(2), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(2, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-2"), new java.math.BigDecimal("1E19")));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<java.math.BigDecimal> borderValue4JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue5 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList((java.math.BigDecimal) null, java.math.BigDecimal.ZERO.setScale(2), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(2, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-2"), new java.math.BigDecimal("1E19")));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<java.math.BigDecimal> borderValue5JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Money/NullableSetOfOneMoniesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Money/NullableSetOfOneMoniesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Money;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfOneMoniesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.math.BigDecimal> defaultValueJsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue1 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(2)));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.math.BigDecimal> borderValue1JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue2 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(new java.math.BigDecimal("1E19")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.math.BigDecimal> borderValue2JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue3 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(2), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(2, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-2"), new java.math.BigDecimal("1E19")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.math.BigDecimal> borderValue3JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertNullableSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Money/OneArrayOfNullableMoniesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Money/OneArrayOfNullableMoniesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Money;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfNullableMoniesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.math.BigDecimal[] defaultValue = new java.math.BigDecimal[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.math.BigDecimal[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue1 = new java.math.BigDecimal[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.math.BigDecimal[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue2 = new java.math.BigDecimal[] { java.math.BigDecimal.ZERO.setScale(2) };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.math.BigDecimal[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue3 = new java.math.BigDecimal[] { new java.math.BigDecimal("1E19") };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.math.BigDecimal[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue4 = new java.math.BigDecimal[] { java.math.BigDecimal.ZERO.setScale(2), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(2, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-2"), new java.math.BigDecimal("1E19") };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.math.BigDecimal[] borderValue4JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue5 = new java.math.BigDecimal[] { null, java.math.BigDecimal.ZERO.setScale(2), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(2, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-2"), new java.math.BigDecimal("1E19") };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.math.BigDecimal[] borderValue5JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Money/OneArrayOfOneMoniesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Money/OneArrayOfOneMoniesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Money;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfOneMoniesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.math.BigDecimal[] defaultValue = new java.math.BigDecimal[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.math.BigDecimal[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue1 = new java.math.BigDecimal[] { java.math.BigDecimal.ZERO.setScale(2) };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.math.BigDecimal[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue2 = new java.math.BigDecimal[] { new java.math.BigDecimal("1E19") };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.math.BigDecimal[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.math.BigDecimal[] borderValue3 = new java.math.BigDecimal[] { java.math.BigDecimal.ZERO.setScale(2), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(2, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-2"), new java.math.BigDecimal("1E19") };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.math.BigDecimal[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Money/OneListOfNullableMoniesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Money/OneListOfNullableMoniesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Money;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfNullableMoniesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.math.BigDecimal> defaultValue = new java.util.ArrayList<java.math.BigDecimal>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.math.BigDecimal> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue1 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList((java.math.BigDecimal) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.math.BigDecimal> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue2 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(2)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.math.BigDecimal> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue3 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(new java.math.BigDecimal("1E19")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.math.BigDecimal> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue4 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(2), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(2, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-2"), new java.math.BigDecimal("1E19")));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<java.math.BigDecimal> borderValue4JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue5 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList((java.math.BigDecimal) null, java.math.BigDecimal.ZERO.setScale(2), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(2, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-2"), new java.math.BigDecimal("1E19")));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<java.math.BigDecimal> borderValue5JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Money/OneListOfOneMoniesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Money/OneListOfOneMoniesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Money;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfOneMoniesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.math.BigDecimal> defaultValue = new java.util.ArrayList<java.math.BigDecimal>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.math.BigDecimal> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue1 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(2)));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.math.BigDecimal> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue2 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(new java.math.BigDecimal("1E19")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.math.BigDecimal> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.math.BigDecimal> borderValue3 = new java.util.ArrayList<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(2), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(2, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-2"), new java.math.BigDecimal("1E19")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.math.BigDecimal> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Money/OneMoneyDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Money/OneMoneyDefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Money;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneMoneyDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.math.BigDecimal defaultValue = java.math.BigDecimal.ZERO.setScale(2);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.math.BigDecimal defaultValueJsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.math.BigDecimal borderValue1 = java.math.BigDecimal.ONE;
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.math.BigDecimal borderValue1JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.math.BigDecimal borderValue2 = new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(2, java.math.BigDecimal.ROUND_HALF_UP);
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.math.BigDecimal borderValue2JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.math.BigDecimal borderValue3 = new java.math.BigDecimal("-1E-2");
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.math.BigDecimal borderValue3JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.math.BigDecimal borderValue4 = new java.math.BigDecimal("1E19");
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.math.BigDecimal borderValue4JsonDeserialized = jsonSerialization.deserialize(java.math.BigDecimal.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Money/OneSetOfNullableMoniesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Money/OneSetOfNullableMoniesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Money;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfNullableMoniesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> defaultValue = new java.util.HashSet<java.math.BigDecimal>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.math.BigDecimal> defaultValueJsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue1 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList((java.math.BigDecimal) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.math.BigDecimal> borderValue1JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue2 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(2)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.math.BigDecimal> borderValue2JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue3 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(new java.math.BigDecimal("1E19")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.math.BigDecimal> borderValue3JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue4 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(2), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(2, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-2"), new java.math.BigDecimal("1E19")));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<java.math.BigDecimal> borderValue4JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue5 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList((java.math.BigDecimal) null, java.math.BigDecimal.ZERO.setScale(2), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(2, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-2"), new java.math.BigDecimal("1E19")));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<java.math.BigDecimal> borderValue5JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Money/OneSetOfOneMoniesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Money/OneSetOfOneMoniesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Money;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfOneMoniesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> defaultValue = new java.util.HashSet<java.math.BigDecimal>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.math.BigDecimal> defaultValueJsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue1 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(2)));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.math.BigDecimal> borderValue1JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue2 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(new java.math.BigDecimal("1E19")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.math.BigDecimal> borderValue2JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.math.BigDecimal> borderValue3 = new java.util.HashSet<java.math.BigDecimal>(java.util.Arrays.asList(java.math.BigDecimal.ZERO.setScale(2), java.math.BigDecimal.ONE, new java.math.BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679").setScale(2, java.math.BigDecimal.ROUND_HALF_UP), new java.math.BigDecimal("-1E-2"), new java.math.BigDecimal("1E19")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.math.BigDecimal> borderValue3JsonDeserialized = new java.util.HashSet<java.math.BigDecimal>(jsonSerialization.deserializeList(java.math.BigDecimal.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.MoneyAsserts.assertOneSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Point/NullableArrayOfNullablePointsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Point/NullableArrayOfNullablePointsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Point;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfNullablePointsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.awt.Point[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.awt.Point[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.awt.Point[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.awt.Point[] borderValue1 = new java.awt.Point[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.awt.Point[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.awt.Point[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.awt.Point[] borderValue2 = new java.awt.Point[] { new java.awt.Point() };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.awt.Point[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.awt.Point[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.awt.Point[] borderValue3 = new java.awt.Point[] { new java.awt.Point(0, 1000000000) };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.awt.Point[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.awt.Point[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.awt.Point[] borderValue4 = new java.awt.Point[] { new java.awt.Point(), new java.awt.Point(Integer.MIN_VALUE, Integer.MIN_VALUE), new java.awt.Point(Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Point(0, -1000000000), new java.awt.Point(0, 1000000000) };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.awt.Point[] borderValue4JsonDeserialized = jsonSerialization.deserialize(java.awt.Point[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.awt.Point[] borderValue5 = new java.awt.Point[] { null, new java.awt.Point(), new java.awt.Point(Integer.MIN_VALUE, Integer.MIN_VALUE), new java.awt.Point(Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Point(0, -1000000000), new java.awt.Point(0, 1000000000) };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.awt.Point[] borderValue5JsonDeserialized = jsonSerialization.deserialize(java.awt.Point[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Point/NullableArrayOfOnePointsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Point/NullableArrayOfOnePointsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Point;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfOnePointsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.awt.Point[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.awt.Point[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.awt.Point[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.awt.Point[] borderValue1 = new java.awt.Point[] { new java.awt.Point() };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.awt.Point[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.awt.Point[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.awt.Point[] borderValue2 = new java.awt.Point[] { new java.awt.Point(0, 1000000000) };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.awt.Point[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.awt.Point[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.awt.Point[] borderValue3 = new java.awt.Point[] { new java.awt.Point(), new java.awt.Point(Integer.MIN_VALUE, Integer.MIN_VALUE), new java.awt.Point(Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Point(0, -1000000000), new java.awt.Point(0, 1000000000) };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.awt.Point[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.awt.Point[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Point/NullableListOfNullablePointsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Point/NullableListOfNullablePointsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Point;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfNullablePointsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.awt.Point> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.awt.Point> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.awt.Point.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.awt.Point> borderValue1 = new java.util.ArrayList<java.awt.Point>(java.util.Arrays.asList((java.awt.Point) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.awt.Point> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.awt.Point.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.awt.Point> borderValue2 = new java.util.ArrayList<java.awt.Point>(java.util.Arrays.asList(new java.awt.Point()));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.awt.Point> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.awt.Point.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.awt.Point> borderValue3 = new java.util.ArrayList<java.awt.Point>(java.util.Arrays.asList(new java.awt.Point(0, 1000000000)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.awt.Point> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.awt.Point.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<java.awt.Point> borderValue4 = new java.util.ArrayList<java.awt.Point>(java.util.Arrays.asList(new java.awt.Point(), new java.awt.Point(Integer.MIN_VALUE, Integer.MIN_VALUE), new java.awt.Point(Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Point(0, -1000000000), new java.awt.Point(0, 1000000000)));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<java.awt.Point> borderValue4JsonDeserialized = jsonSerialization.deserializeList(java.awt.Point.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<java.awt.Point> borderValue5 = new java.util.ArrayList<java.awt.Point>(java.util.Arrays.asList((java.awt.Point) null, new java.awt.Point(), new java.awt.Point(Integer.MIN_VALUE, Integer.MIN_VALUE), new java.awt.Point(Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Point(0, -1000000000), new java.awt.Point(0, 1000000000)));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<java.awt.Point> borderValue5JsonDeserialized = jsonSerialization.deserializeList(java.awt.Point.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Point/NullableListOfOnePointsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Point/NullableListOfOnePointsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Point;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfOnePointsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.awt.Point> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.awt.Point> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.awt.Point.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.awt.Point> borderValue1 = new java.util.ArrayList<java.awt.Point>(java.util.Arrays.asList(new java.awt.Point()));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.awt.Point> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.awt.Point.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.awt.Point> borderValue2 = new java.util.ArrayList<java.awt.Point>(java.util.Arrays.asList(new java.awt.Point(0, 1000000000)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.awt.Point> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.awt.Point.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.awt.Point> borderValue3 = new java.util.ArrayList<java.awt.Point>(java.util.Arrays.asList(new java.awt.Point(), new java.awt.Point(Integer.MIN_VALUE, Integer.MIN_VALUE), new java.awt.Point(Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Point(0, -1000000000), new java.awt.Point(0, 1000000000)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.awt.Point> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.awt.Point.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Point/NullablePointDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Point/NullablePointDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Point;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullablePointDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.awt.Point defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.awt.Point defaultValueJsonDeserialized = jsonSerialization.deserialize(java.awt.Point.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.awt.Point borderValue1 = new java.awt.Point();
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.awt.Point borderValue1JsonDeserialized = jsonSerialization.deserialize(java.awt.Point.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.awt.Point borderValue2 = new java.awt.Point(Integer.MIN_VALUE, Integer.MIN_VALUE);
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.awt.Point borderValue2JsonDeserialized = jsonSerialization.deserialize(java.awt.Point.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.awt.Point borderValue3 = new java.awt.Point(Integer.MAX_VALUE, Integer.MAX_VALUE);
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.awt.Point borderValue3JsonDeserialized = jsonSerialization.deserialize(java.awt.Point.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.awt.Point borderValue4 = new java.awt.Point(0, -1000000000);
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.awt.Point borderValue4JsonDeserialized = jsonSerialization.deserialize(java.awt.Point.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.awt.Point borderValue5 = new java.awt.Point(0, 1000000000);
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.awt.Point borderValue5JsonDeserialized = jsonSerialization.deserialize(java.awt.Point.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Point/NullableSetOfNullablePointsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Point/NullableSetOfNullablePointsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Point;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfNullablePointsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.awt.Point> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.awt.Point> defaultValueJsonDeserialized = new java.util.HashSet<java.awt.Point>(jsonSerialization.deserializeList(java.awt.Point.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.awt.Point> borderValue1 = new java.util.HashSet<java.awt.Point>(java.util.Arrays.asList((java.awt.Point) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.awt.Point> borderValue1JsonDeserialized = new java.util.HashSet<java.awt.Point>(jsonSerialization.deserializeList(java.awt.Point.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.awt.Point> borderValue2 = new java.util.HashSet<java.awt.Point>(java.util.Arrays.asList(new java.awt.Point()));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.awt.Point> borderValue2JsonDeserialized = new java.util.HashSet<java.awt.Point>(jsonSerialization.deserializeList(java.awt.Point.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.awt.Point> borderValue3 = new java.util.HashSet<java.awt.Point>(java.util.Arrays.asList(new java.awt.Point(0, 1000000000)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.awt.Point> borderValue3JsonDeserialized = new java.util.HashSet<java.awt.Point>(jsonSerialization.deserializeList(java.awt.Point.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<java.awt.Point> borderValue4 = new java.util.HashSet<java.awt.Point>(java.util.Arrays.asList(new java.awt.Point(), new java.awt.Point(Integer.MIN_VALUE, Integer.MIN_VALUE), new java.awt.Point(Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Point(0, -1000000000), new java.awt.Point(0, 1000000000)));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<java.awt.Point> borderValue4JsonDeserialized = new java.util.HashSet<java.awt.Point>(jsonSerialization.deserializeList(java.awt.Point.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<java.awt.Point> borderValue5 = new java.util.HashSet<java.awt.Point>(java.util.Arrays.asList((java.awt.Point) null, new java.awt.Point(), new java.awt.Point(Integer.MIN_VALUE, Integer.MIN_VALUE), new java.awt.Point(Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Point(0, -1000000000), new java.awt.Point(0, 1000000000)));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<java.awt.Point> borderValue5JsonDeserialized = new java.util.HashSet<java.awt.Point>(jsonSerialization.deserializeList(java.awt.Point.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Point/NullableSetOfOnePointsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Point/NullableSetOfOnePointsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Point;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfOnePointsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.awt.Point> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.awt.Point> defaultValueJsonDeserialized = new java.util.HashSet<java.awt.Point>(jsonSerialization.deserializeList(java.awt.Point.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.awt.Point> borderValue1 = new java.util.HashSet<java.awt.Point>(java.util.Arrays.asList(new java.awt.Point()));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.awt.Point> borderValue1JsonDeserialized = new java.util.HashSet<java.awt.Point>(jsonSerialization.deserializeList(java.awt.Point.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.awt.Point> borderValue2 = new java.util.HashSet<java.awt.Point>(java.util.Arrays.asList(new java.awt.Point(0, 1000000000)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.awt.Point> borderValue2JsonDeserialized = new java.util.HashSet<java.awt.Point>(jsonSerialization.deserializeList(java.awt.Point.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.awt.Point> borderValue3 = new java.util.HashSet<java.awt.Point>(java.util.Arrays.asList(new java.awt.Point(), new java.awt.Point(Integer.MIN_VALUE, Integer.MIN_VALUE), new java.awt.Point(Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Point(0, -1000000000), new java.awt.Point(0, 1000000000)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.awt.Point> borderValue3JsonDeserialized = new java.util.HashSet<java.awt.Point>(jsonSerialization.deserializeList(java.awt.Point.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertNullableSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Point/OneArrayOfNullablePointsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Point/OneArrayOfNullablePointsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Point;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfNullablePointsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.awt.Point[] defaultValue = new java.awt.Point[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.awt.Point[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.awt.Point[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.awt.Point[] borderValue1 = new java.awt.Point[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.awt.Point[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.awt.Point[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.awt.Point[] borderValue2 = new java.awt.Point[] { new java.awt.Point() };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.awt.Point[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.awt.Point[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.awt.Point[] borderValue3 = new java.awt.Point[] { new java.awt.Point(0, 1000000000) };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.awt.Point[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.awt.Point[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.awt.Point[] borderValue4 = new java.awt.Point[] { new java.awt.Point(), new java.awt.Point(Integer.MIN_VALUE, Integer.MIN_VALUE), new java.awt.Point(Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Point(0, -1000000000), new java.awt.Point(0, 1000000000) };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.awt.Point[] borderValue4JsonDeserialized = jsonSerialization.deserialize(java.awt.Point[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.awt.Point[] borderValue5 = new java.awt.Point[] { null, new java.awt.Point(), new java.awt.Point(Integer.MIN_VALUE, Integer.MIN_VALUE), new java.awt.Point(Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Point(0, -1000000000), new java.awt.Point(0, 1000000000) };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.awt.Point[] borderValue5JsonDeserialized = jsonSerialization.deserialize(java.awt.Point[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Point/OneArrayOfOnePointsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Point/OneArrayOfOnePointsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Point;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfOnePointsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.awt.Point[] defaultValue = new java.awt.Point[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.awt.Point[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.awt.Point[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.awt.Point[] borderValue1 = new java.awt.Point[] { new java.awt.Point() };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.awt.Point[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.awt.Point[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.awt.Point[] borderValue2 = new java.awt.Point[] { new java.awt.Point(0, 1000000000) };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.awt.Point[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.awt.Point[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.awt.Point[] borderValue3 = new java.awt.Point[] { new java.awt.Point(), new java.awt.Point(Integer.MIN_VALUE, Integer.MIN_VALUE), new java.awt.Point(Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Point(0, -1000000000), new java.awt.Point(0, 1000000000) };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.awt.Point[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.awt.Point[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Point/OneListOfNullablePointsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Point/OneListOfNullablePointsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Point;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfNullablePointsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.awt.Point> defaultValue = new java.util.ArrayList<java.awt.Point>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.awt.Point> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.awt.Point.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.awt.Point> borderValue1 = new java.util.ArrayList<java.awt.Point>(java.util.Arrays.asList((java.awt.Point) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.awt.Point> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.awt.Point.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.awt.Point> borderValue2 = new java.util.ArrayList<java.awt.Point>(java.util.Arrays.asList(new java.awt.Point()));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.awt.Point> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.awt.Point.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.awt.Point> borderValue3 = new java.util.ArrayList<java.awt.Point>(java.util.Arrays.asList(new java.awt.Point(0, 1000000000)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.awt.Point> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.awt.Point.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<java.awt.Point> borderValue4 = new java.util.ArrayList<java.awt.Point>(java.util.Arrays.asList(new java.awt.Point(), new java.awt.Point(Integer.MIN_VALUE, Integer.MIN_VALUE), new java.awt.Point(Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Point(0, -1000000000), new java.awt.Point(0, 1000000000)));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<java.awt.Point> borderValue4JsonDeserialized = jsonSerialization.deserializeList(java.awt.Point.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<java.awt.Point> borderValue5 = new java.util.ArrayList<java.awt.Point>(java.util.Arrays.asList((java.awt.Point) null, new java.awt.Point(), new java.awt.Point(Integer.MIN_VALUE, Integer.MIN_VALUE), new java.awt.Point(Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Point(0, -1000000000), new java.awt.Point(0, 1000000000)));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<java.awt.Point> borderValue5JsonDeserialized = jsonSerialization.deserializeList(java.awt.Point.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Point/OneListOfOnePointsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Point/OneListOfOnePointsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Point;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfOnePointsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.awt.Point> defaultValue = new java.util.ArrayList<java.awt.Point>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.awt.Point> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.awt.Point.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.awt.Point> borderValue1 = new java.util.ArrayList<java.awt.Point>(java.util.Arrays.asList(new java.awt.Point()));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.awt.Point> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.awt.Point.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.awt.Point> borderValue2 = new java.util.ArrayList<java.awt.Point>(java.util.Arrays.asList(new java.awt.Point(0, 1000000000)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.awt.Point> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.awt.Point.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.awt.Point> borderValue3 = new java.util.ArrayList<java.awt.Point>(java.util.Arrays.asList(new java.awt.Point(), new java.awt.Point(Integer.MIN_VALUE, Integer.MIN_VALUE), new java.awt.Point(Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Point(0, -1000000000), new java.awt.Point(0, 1000000000)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.awt.Point> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.awt.Point.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Point/OnePointDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Point/OnePointDefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Point;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OnePointDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.awt.Point defaultValue = new java.awt.Point();
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.awt.Point defaultValueJsonDeserialized = jsonSerialization.deserialize(java.awt.Point.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.awt.Point borderValue1 = new java.awt.Point(Integer.MIN_VALUE, Integer.MIN_VALUE);
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.awt.Point borderValue1JsonDeserialized = jsonSerialization.deserialize(java.awt.Point.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.awt.Point borderValue2 = new java.awt.Point(Integer.MAX_VALUE, Integer.MAX_VALUE);
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.awt.Point borderValue2JsonDeserialized = jsonSerialization.deserialize(java.awt.Point.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.awt.Point borderValue3 = new java.awt.Point(0, -1000000000);
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.awt.Point borderValue3JsonDeserialized = jsonSerialization.deserialize(java.awt.Point.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.awt.Point borderValue4 = new java.awt.Point(0, 1000000000);
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.awt.Point borderValue4JsonDeserialized = jsonSerialization.deserialize(java.awt.Point.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Point/OneSetOfNullablePointsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Point/OneSetOfNullablePointsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Point;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfNullablePointsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.awt.Point> defaultValue = new java.util.HashSet<java.awt.Point>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.awt.Point> defaultValueJsonDeserialized = new java.util.HashSet<java.awt.Point>(jsonSerialization.deserializeList(java.awt.Point.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.awt.Point> borderValue1 = new java.util.HashSet<java.awt.Point>(java.util.Arrays.asList((java.awt.Point) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.awt.Point> borderValue1JsonDeserialized = new java.util.HashSet<java.awt.Point>(jsonSerialization.deserializeList(java.awt.Point.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.awt.Point> borderValue2 = new java.util.HashSet<java.awt.Point>(java.util.Arrays.asList(new java.awt.Point()));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.awt.Point> borderValue2JsonDeserialized = new java.util.HashSet<java.awt.Point>(jsonSerialization.deserializeList(java.awt.Point.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.awt.Point> borderValue3 = new java.util.HashSet<java.awt.Point>(java.util.Arrays.asList(new java.awt.Point(0, 1000000000)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.awt.Point> borderValue3JsonDeserialized = new java.util.HashSet<java.awt.Point>(jsonSerialization.deserializeList(java.awt.Point.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<java.awt.Point> borderValue4 = new java.util.HashSet<java.awt.Point>(java.util.Arrays.asList(new java.awt.Point(), new java.awt.Point(Integer.MIN_VALUE, Integer.MIN_VALUE), new java.awt.Point(Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Point(0, -1000000000), new java.awt.Point(0, 1000000000)));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<java.awt.Point> borderValue4JsonDeserialized = new java.util.HashSet<java.awt.Point>(jsonSerialization.deserializeList(java.awt.Point.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<java.awt.Point> borderValue5 = new java.util.HashSet<java.awt.Point>(java.util.Arrays.asList((java.awt.Point) null, new java.awt.Point(), new java.awt.Point(Integer.MIN_VALUE, Integer.MIN_VALUE), new java.awt.Point(Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Point(0, -1000000000), new java.awt.Point(0, 1000000000)));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<java.awt.Point> borderValue5JsonDeserialized = new java.util.HashSet<java.awt.Point>(jsonSerialization.deserializeList(java.awt.Point.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Point/OneSetOfOnePointsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Point/OneSetOfOnePointsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Point;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfOnePointsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.awt.Point> defaultValue = new java.util.HashSet<java.awt.Point>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.awt.Point> defaultValueJsonDeserialized = new java.util.HashSet<java.awt.Point>(jsonSerialization.deserializeList(java.awt.Point.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.awt.Point> borderValue1 = new java.util.HashSet<java.awt.Point>(java.util.Arrays.asList(new java.awt.Point()));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.awt.Point> borderValue1JsonDeserialized = new java.util.HashSet<java.awt.Point>(jsonSerialization.deserializeList(java.awt.Point.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.awt.Point> borderValue2 = new java.util.HashSet<java.awt.Point>(java.util.Arrays.asList(new java.awt.Point(0, 1000000000)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.awt.Point> borderValue2JsonDeserialized = new java.util.HashSet<java.awt.Point>(jsonSerialization.deserializeList(java.awt.Point.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.awt.Point> borderValue3 = new java.util.HashSet<java.awt.Point>(java.util.Arrays.asList(new java.awt.Point(), new java.awt.Point(Integer.MIN_VALUE, Integer.MIN_VALUE), new java.awt.Point(Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Point(0, -1000000000), new java.awt.Point(0, 1000000000)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.awt.Point> borderValue3JsonDeserialized = new java.util.HashSet<java.awt.Point>(jsonSerialization.deserializeList(java.awt.Point.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.PointAsserts.assertOneSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Rectangle/NullableArrayOfNullableRectanglesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Rectangle/NullableArrayOfNullableRectanglesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Rectangle;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfNullableRectanglesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.awt.geom.Rectangle2D[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.awt.geom.Rectangle2D[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.awt.geom.Rectangle2D[] borderValue1 = new java.awt.geom.Rectangle2D[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.awt.geom.Rectangle2D[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.awt.geom.Rectangle2D[] borderValue2 = new java.awt.geom.Rectangle2D[] { new java.awt.geom.Rectangle2D.Float() };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.awt.geom.Rectangle2D[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.awt.geom.Rectangle2D[] borderValue3 = new java.awt.geom.Rectangle2D[] { new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001) };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.awt.geom.Rectangle2D[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.awt.geom.Rectangle2D[] borderValue4 = new java.awt.geom.Rectangle2D[] { new java.awt.geom.Rectangle2D.Float(), new java.awt.Rectangle(Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Rectangle(-1000000000, -1000000000, 1000000000, 1000000000), new java.awt.geom.Rectangle2D.Float(Float.MIN_VALUE, Float.MIN_VALUE, Float.MAX_VALUE, Float.MAX_VALUE), new java.awt.geom.Rectangle2D.Float(-1.0000001f, -1.0000001f, 1.0000001f, 1.0000001f), new java.awt.geom.Rectangle2D.Double(Double.MIN_VALUE, Double.MIN_VALUE, Double.MAX_VALUE, Double.MAX_VALUE), new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001) };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.awt.geom.Rectangle2D[] borderValue4JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.awt.geom.Rectangle2D[] borderValue5 = new java.awt.geom.Rectangle2D[] { null, new java.awt.geom.Rectangle2D.Float(), new java.awt.Rectangle(Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Rectangle(-1000000000, -1000000000, 1000000000, 1000000000), new java.awt.geom.Rectangle2D.Float(Float.MIN_VALUE, Float.MIN_VALUE, Float.MAX_VALUE, Float.MAX_VALUE), new java.awt.geom.Rectangle2D.Float(-1.0000001f, -1.0000001f, 1.0000001f, 1.0000001f), new java.awt.geom.Rectangle2D.Double(Double.MIN_VALUE, Double.MIN_VALUE, Double.MAX_VALUE, Double.MAX_VALUE), new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001) };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.awt.geom.Rectangle2D[] borderValue5JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Rectangle/NullableArrayOfOneRectanglesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Rectangle/NullableArrayOfOneRectanglesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Rectangle;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfOneRectanglesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.awt.geom.Rectangle2D[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.awt.geom.Rectangle2D[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.awt.geom.Rectangle2D[] borderValue1 = new java.awt.geom.Rectangle2D[] { new java.awt.geom.Rectangle2D.Float() };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.awt.geom.Rectangle2D[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.awt.geom.Rectangle2D[] borderValue2 = new java.awt.geom.Rectangle2D[] { new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001) };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.awt.geom.Rectangle2D[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.awt.geom.Rectangle2D[] borderValue3 = new java.awt.geom.Rectangle2D[] { new java.awt.geom.Rectangle2D.Float(), new java.awt.Rectangle(Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Rectangle(-1000000000, -1000000000, 1000000000, 1000000000), new java.awt.geom.Rectangle2D.Float(Float.MIN_VALUE, Float.MIN_VALUE, Float.MAX_VALUE, Float.MAX_VALUE), new java.awt.geom.Rectangle2D.Float(-1.0000001f, -1.0000001f, 1.0000001f, 1.0000001f), new java.awt.geom.Rectangle2D.Double(Double.MIN_VALUE, Double.MIN_VALUE, Double.MAX_VALUE, Double.MAX_VALUE), new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001) };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.awt.geom.Rectangle2D[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Rectangle/NullableListOfNullableRectanglesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Rectangle/NullableListOfNullableRectanglesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Rectangle;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfNullableRectanglesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.awt.geom.Rectangle2D> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.awt.geom.Rectangle2D> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue1 = new java.util.ArrayList<java.awt.geom.Rectangle2D>(java.util.Arrays.asList((java.awt.geom.Rectangle2D) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue2 = new java.util.ArrayList<java.awt.geom.Rectangle2D>(java.util.Arrays.asList(new java.awt.geom.Rectangle2D.Float()));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue3 = new java.util.ArrayList<java.awt.geom.Rectangle2D>(java.util.Arrays.asList(new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue4 = new java.util.ArrayList<java.awt.geom.Rectangle2D>(java.util.Arrays.asList(new java.awt.geom.Rectangle2D.Float(), new java.awt.Rectangle(Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Rectangle(-1000000000, -1000000000, 1000000000, 1000000000), new java.awt.geom.Rectangle2D.Float(Float.MIN_VALUE, Float.MIN_VALUE, Float.MAX_VALUE, Float.MAX_VALUE), new java.awt.geom.Rectangle2D.Float(-1.0000001f, -1.0000001f, 1.0000001f, 1.0000001f), new java.awt.geom.Rectangle2D.Double(Double.MIN_VALUE, Double.MIN_VALUE, Double.MAX_VALUE, Double.MAX_VALUE), new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue4JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue5 = new java.util.ArrayList<java.awt.geom.Rectangle2D>(java.util.Arrays.asList((java.awt.geom.Rectangle2D) null, new java.awt.geom.Rectangle2D.Float(), new java.awt.Rectangle(Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Rectangle(-1000000000, -1000000000, 1000000000, 1000000000), new java.awt.geom.Rectangle2D.Float(Float.MIN_VALUE, Float.MIN_VALUE, Float.MAX_VALUE, Float.MAX_VALUE), new java.awt.geom.Rectangle2D.Float(-1.0000001f, -1.0000001f, 1.0000001f, 1.0000001f), new java.awt.geom.Rectangle2D.Double(Double.MIN_VALUE, Double.MIN_VALUE, Double.MAX_VALUE, Double.MAX_VALUE), new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue5JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Rectangle/NullableListOfOneRectanglesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Rectangle/NullableListOfOneRectanglesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Rectangle;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfOneRectanglesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.awt.geom.Rectangle2D> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.awt.geom.Rectangle2D> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue1 = new java.util.ArrayList<java.awt.geom.Rectangle2D>(java.util.Arrays.asList(new java.awt.geom.Rectangle2D.Float()));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue2 = new java.util.ArrayList<java.awt.geom.Rectangle2D>(java.util.Arrays.asList(new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue3 = new java.util.ArrayList<java.awt.geom.Rectangle2D>(java.util.Arrays.asList(new java.awt.geom.Rectangle2D.Float(), new java.awt.Rectangle(Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Rectangle(-1000000000, -1000000000, 1000000000, 1000000000), new java.awt.geom.Rectangle2D.Float(Float.MIN_VALUE, Float.MIN_VALUE, Float.MAX_VALUE, Float.MAX_VALUE), new java.awt.geom.Rectangle2D.Float(-1.0000001f, -1.0000001f, 1.0000001f, 1.0000001f), new java.awt.geom.Rectangle2D.Double(Double.MIN_VALUE, Double.MIN_VALUE, Double.MAX_VALUE, Double.MAX_VALUE), new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Rectangle/NullableRectangleDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Rectangle/NullableRectangleDefaultValueTurtle.java
@@ -1,0 +1,91 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Rectangle;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableRectangleDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.awt.geom.Rectangle2D defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.awt.geom.Rectangle2D defaultValueJsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.awt.geom.Rectangle2D borderValue1 = new java.awt.geom.Rectangle2D.Float();
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.awt.geom.Rectangle2D borderValue1JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.awt.geom.Rectangle2D borderValue2 = new java.awt.Rectangle(Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE);
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.awt.geom.Rectangle2D borderValue2JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.awt.geom.Rectangle2D borderValue3 = new java.awt.Rectangle(-1000000000, -1000000000, 1000000000, 1000000000);
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.awt.geom.Rectangle2D borderValue3JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.awt.geom.Rectangle2D borderValue4 = new java.awt.geom.Rectangle2D.Float(Float.MIN_VALUE, Float.MIN_VALUE, Float.MAX_VALUE, Float.MAX_VALUE);
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.awt.geom.Rectangle2D borderValue4JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.awt.geom.Rectangle2D borderValue5 = new java.awt.geom.Rectangle2D.Float(-1.0000001f, -1.0000001f, 1.0000001f, 1.0000001f);
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.awt.geom.Rectangle2D borderValue5JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue6Equality() throws IOException {
+        final java.awt.geom.Rectangle2D borderValue6 = new java.awt.geom.Rectangle2D.Double(Double.MIN_VALUE, Double.MIN_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
+        final Bytes borderValue6JsonSerialized = jsonSerialization.serialize(borderValue6);
+        final java.awt.geom.Rectangle2D borderValue6JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D.class, borderValue6JsonSerialized.content, borderValue6JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableEquals(borderValue6, borderValue6JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue7Equality() throws IOException {
+        final java.awt.geom.Rectangle2D borderValue7 = new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001);
+        final Bytes borderValue7JsonSerialized = jsonSerialization.serialize(borderValue7);
+        final java.awt.geom.Rectangle2D borderValue7JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D.class, borderValue7JsonSerialized.content, borderValue7JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableEquals(borderValue7, borderValue7JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Rectangle/NullableSetOfNullableRectanglesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Rectangle/NullableSetOfNullableRectanglesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Rectangle;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfNullableRectanglesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.awt.geom.Rectangle2D> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.awt.geom.Rectangle2D> defaultValueJsonDeserialized = new java.util.HashSet<java.awt.geom.Rectangle2D>(jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue1 = new java.util.HashSet<java.awt.geom.Rectangle2D>(java.util.Arrays.asList((java.awt.geom.Rectangle2D) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue1JsonDeserialized = new java.util.HashSet<java.awt.geom.Rectangle2D>(jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue2 = new java.util.HashSet<java.awt.geom.Rectangle2D>(java.util.Arrays.asList(new java.awt.geom.Rectangle2D.Float()));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue2JsonDeserialized = new java.util.HashSet<java.awt.geom.Rectangle2D>(jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue3 = new java.util.HashSet<java.awt.geom.Rectangle2D>(java.util.Arrays.asList(new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue3JsonDeserialized = new java.util.HashSet<java.awt.geom.Rectangle2D>(jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue4 = new java.util.HashSet<java.awt.geom.Rectangle2D>(java.util.Arrays.asList(new java.awt.geom.Rectangle2D.Float(), new java.awt.Rectangle(Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Rectangle(-1000000000, -1000000000, 1000000000, 1000000000), new java.awt.geom.Rectangle2D.Float(Float.MIN_VALUE, Float.MIN_VALUE, Float.MAX_VALUE, Float.MAX_VALUE), new java.awt.geom.Rectangle2D.Float(-1.0000001f, -1.0000001f, 1.0000001f, 1.0000001f), new java.awt.geom.Rectangle2D.Double(Double.MIN_VALUE, Double.MIN_VALUE, Double.MAX_VALUE, Double.MAX_VALUE), new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue4JsonDeserialized = new java.util.HashSet<java.awt.geom.Rectangle2D>(jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue5 = new java.util.HashSet<java.awt.geom.Rectangle2D>(java.util.Arrays.asList((java.awt.geom.Rectangle2D) null, new java.awt.geom.Rectangle2D.Float(), new java.awt.Rectangle(Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Rectangle(-1000000000, -1000000000, 1000000000, 1000000000), new java.awt.geom.Rectangle2D.Float(Float.MIN_VALUE, Float.MIN_VALUE, Float.MAX_VALUE, Float.MAX_VALUE), new java.awt.geom.Rectangle2D.Float(-1.0000001f, -1.0000001f, 1.0000001f, 1.0000001f), new java.awt.geom.Rectangle2D.Double(Double.MIN_VALUE, Double.MIN_VALUE, Double.MAX_VALUE, Double.MAX_VALUE), new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue5JsonDeserialized = new java.util.HashSet<java.awt.geom.Rectangle2D>(jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Rectangle/NullableSetOfOneRectanglesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Rectangle/NullableSetOfOneRectanglesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Rectangle;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfOneRectanglesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.awt.geom.Rectangle2D> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.awt.geom.Rectangle2D> defaultValueJsonDeserialized = new java.util.HashSet<java.awt.geom.Rectangle2D>(jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue1 = new java.util.HashSet<java.awt.geom.Rectangle2D>(java.util.Arrays.asList(new java.awt.geom.Rectangle2D.Float()));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue1JsonDeserialized = new java.util.HashSet<java.awt.geom.Rectangle2D>(jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue2 = new java.util.HashSet<java.awt.geom.Rectangle2D>(java.util.Arrays.asList(new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue2JsonDeserialized = new java.util.HashSet<java.awt.geom.Rectangle2D>(jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue3 = new java.util.HashSet<java.awt.geom.Rectangle2D>(java.util.Arrays.asList(new java.awt.geom.Rectangle2D.Float(), new java.awt.Rectangle(Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Rectangle(-1000000000, -1000000000, 1000000000, 1000000000), new java.awt.geom.Rectangle2D.Float(Float.MIN_VALUE, Float.MIN_VALUE, Float.MAX_VALUE, Float.MAX_VALUE), new java.awt.geom.Rectangle2D.Float(-1.0000001f, -1.0000001f, 1.0000001f, 1.0000001f), new java.awt.geom.Rectangle2D.Double(Double.MIN_VALUE, Double.MIN_VALUE, Double.MAX_VALUE, Double.MAX_VALUE), new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue3JsonDeserialized = new java.util.HashSet<java.awt.geom.Rectangle2D>(jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertNullableSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Rectangle/OneArrayOfNullableRectanglesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Rectangle/OneArrayOfNullableRectanglesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Rectangle;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfNullableRectanglesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.awt.geom.Rectangle2D[] defaultValue = new java.awt.geom.Rectangle2D[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.awt.geom.Rectangle2D[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.awt.geom.Rectangle2D[] borderValue1 = new java.awt.geom.Rectangle2D[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.awt.geom.Rectangle2D[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.awt.geom.Rectangle2D[] borderValue2 = new java.awt.geom.Rectangle2D[] { new java.awt.geom.Rectangle2D.Float() };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.awt.geom.Rectangle2D[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.awt.geom.Rectangle2D[] borderValue3 = new java.awt.geom.Rectangle2D[] { new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001) };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.awt.geom.Rectangle2D[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.awt.geom.Rectangle2D[] borderValue4 = new java.awt.geom.Rectangle2D[] { new java.awt.geom.Rectangle2D.Float(), new java.awt.Rectangle(Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Rectangle(-1000000000, -1000000000, 1000000000, 1000000000), new java.awt.geom.Rectangle2D.Float(Float.MIN_VALUE, Float.MIN_VALUE, Float.MAX_VALUE, Float.MAX_VALUE), new java.awt.geom.Rectangle2D.Float(-1.0000001f, -1.0000001f, 1.0000001f, 1.0000001f), new java.awt.geom.Rectangle2D.Double(Double.MIN_VALUE, Double.MIN_VALUE, Double.MAX_VALUE, Double.MAX_VALUE), new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001) };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.awt.geom.Rectangle2D[] borderValue4JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.awt.geom.Rectangle2D[] borderValue5 = new java.awt.geom.Rectangle2D[] { null, new java.awt.geom.Rectangle2D.Float(), new java.awt.Rectangle(Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Rectangle(-1000000000, -1000000000, 1000000000, 1000000000), new java.awt.geom.Rectangle2D.Float(Float.MIN_VALUE, Float.MIN_VALUE, Float.MAX_VALUE, Float.MAX_VALUE), new java.awt.geom.Rectangle2D.Float(-1.0000001f, -1.0000001f, 1.0000001f, 1.0000001f), new java.awt.geom.Rectangle2D.Double(Double.MIN_VALUE, Double.MIN_VALUE, Double.MAX_VALUE, Double.MAX_VALUE), new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001) };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.awt.geom.Rectangle2D[] borderValue5JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Rectangle/OneArrayOfOneRectanglesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Rectangle/OneArrayOfOneRectanglesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Rectangle;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfOneRectanglesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.awt.geom.Rectangle2D[] defaultValue = new java.awt.geom.Rectangle2D[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.awt.geom.Rectangle2D[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.awt.geom.Rectangle2D[] borderValue1 = new java.awt.geom.Rectangle2D[] { new java.awt.geom.Rectangle2D.Float() };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.awt.geom.Rectangle2D[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.awt.geom.Rectangle2D[] borderValue2 = new java.awt.geom.Rectangle2D[] { new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001) };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.awt.geom.Rectangle2D[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.awt.geom.Rectangle2D[] borderValue3 = new java.awt.geom.Rectangle2D[] { new java.awt.geom.Rectangle2D.Float(), new java.awt.Rectangle(Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Rectangle(-1000000000, -1000000000, 1000000000, 1000000000), new java.awt.geom.Rectangle2D.Float(Float.MIN_VALUE, Float.MIN_VALUE, Float.MAX_VALUE, Float.MAX_VALUE), new java.awt.geom.Rectangle2D.Float(-1.0000001f, -1.0000001f, 1.0000001f, 1.0000001f), new java.awt.geom.Rectangle2D.Double(Double.MIN_VALUE, Double.MIN_VALUE, Double.MAX_VALUE, Double.MAX_VALUE), new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001) };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.awt.geom.Rectangle2D[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Rectangle/OneListOfNullableRectanglesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Rectangle/OneListOfNullableRectanglesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Rectangle;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfNullableRectanglesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.awt.geom.Rectangle2D> defaultValue = new java.util.ArrayList<java.awt.geom.Rectangle2D>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.awt.geom.Rectangle2D> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue1 = new java.util.ArrayList<java.awt.geom.Rectangle2D>(java.util.Arrays.asList((java.awt.geom.Rectangle2D) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue2 = new java.util.ArrayList<java.awt.geom.Rectangle2D>(java.util.Arrays.asList(new java.awt.geom.Rectangle2D.Float()));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue3 = new java.util.ArrayList<java.awt.geom.Rectangle2D>(java.util.Arrays.asList(new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue4 = new java.util.ArrayList<java.awt.geom.Rectangle2D>(java.util.Arrays.asList(new java.awt.geom.Rectangle2D.Float(), new java.awt.Rectangle(Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Rectangle(-1000000000, -1000000000, 1000000000, 1000000000), new java.awt.geom.Rectangle2D.Float(Float.MIN_VALUE, Float.MIN_VALUE, Float.MAX_VALUE, Float.MAX_VALUE), new java.awt.geom.Rectangle2D.Float(-1.0000001f, -1.0000001f, 1.0000001f, 1.0000001f), new java.awt.geom.Rectangle2D.Double(Double.MIN_VALUE, Double.MIN_VALUE, Double.MAX_VALUE, Double.MAX_VALUE), new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue4JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue5 = new java.util.ArrayList<java.awt.geom.Rectangle2D>(java.util.Arrays.asList((java.awt.geom.Rectangle2D) null, new java.awt.geom.Rectangle2D.Float(), new java.awt.Rectangle(Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Rectangle(-1000000000, -1000000000, 1000000000, 1000000000), new java.awt.geom.Rectangle2D.Float(Float.MIN_VALUE, Float.MIN_VALUE, Float.MAX_VALUE, Float.MAX_VALUE), new java.awt.geom.Rectangle2D.Float(-1.0000001f, -1.0000001f, 1.0000001f, 1.0000001f), new java.awt.geom.Rectangle2D.Double(Double.MIN_VALUE, Double.MIN_VALUE, Double.MAX_VALUE, Double.MAX_VALUE), new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue5JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Rectangle/OneListOfOneRectanglesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Rectangle/OneListOfOneRectanglesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Rectangle;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfOneRectanglesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.awt.geom.Rectangle2D> defaultValue = new java.util.ArrayList<java.awt.geom.Rectangle2D>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.awt.geom.Rectangle2D> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue1 = new java.util.ArrayList<java.awt.geom.Rectangle2D>(java.util.Arrays.asList(new java.awt.geom.Rectangle2D.Float()));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue2 = new java.util.ArrayList<java.awt.geom.Rectangle2D>(java.util.Arrays.asList(new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue3 = new java.util.ArrayList<java.awt.geom.Rectangle2D>(java.util.Arrays.asList(new java.awt.geom.Rectangle2D.Float(), new java.awt.Rectangle(Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Rectangle(-1000000000, -1000000000, 1000000000, 1000000000), new java.awt.geom.Rectangle2D.Float(Float.MIN_VALUE, Float.MIN_VALUE, Float.MAX_VALUE, Float.MAX_VALUE), new java.awt.geom.Rectangle2D.Float(-1.0000001f, -1.0000001f, 1.0000001f, 1.0000001f), new java.awt.geom.Rectangle2D.Double(Double.MIN_VALUE, Double.MIN_VALUE, Double.MAX_VALUE, Double.MAX_VALUE), new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.awt.geom.Rectangle2D> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Rectangle/OneRectangleDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Rectangle/OneRectangleDefaultValueTurtle.java
@@ -1,0 +1,82 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Rectangle;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneRectangleDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.awt.geom.Rectangle2D defaultValue = new java.awt.geom.Rectangle2D.Float();
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.awt.geom.Rectangle2D defaultValueJsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.awt.geom.Rectangle2D borderValue1 = new java.awt.Rectangle(Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE);
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.awt.geom.Rectangle2D borderValue1JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.awt.geom.Rectangle2D borderValue2 = new java.awt.Rectangle(-1000000000, -1000000000, 1000000000, 1000000000);
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.awt.geom.Rectangle2D borderValue2JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.awt.geom.Rectangle2D borderValue3 = new java.awt.geom.Rectangle2D.Float(Float.MIN_VALUE, Float.MIN_VALUE, Float.MAX_VALUE, Float.MAX_VALUE);
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.awt.geom.Rectangle2D borderValue3JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.awt.geom.Rectangle2D borderValue4 = new java.awt.geom.Rectangle2D.Float(-1.0000001f, -1.0000001f, 1.0000001f, 1.0000001f);
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.awt.geom.Rectangle2D borderValue4JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.awt.geom.Rectangle2D borderValue5 = new java.awt.geom.Rectangle2D.Double(Double.MIN_VALUE, Double.MIN_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.awt.geom.Rectangle2D borderValue5JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue6Equality() throws IOException {
+        final java.awt.geom.Rectangle2D borderValue6 = new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001);
+        final Bytes borderValue6JsonSerialized = jsonSerialization.serialize(borderValue6);
+        final java.awt.geom.Rectangle2D borderValue6JsonDeserialized = jsonSerialization.deserialize(java.awt.geom.Rectangle2D.class, borderValue6JsonSerialized.content, borderValue6JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneEquals(borderValue6, borderValue6JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Rectangle/OneSetOfNullableRectanglesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Rectangle/OneSetOfNullableRectanglesDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Rectangle;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfNullableRectanglesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.awt.geom.Rectangle2D> defaultValue = new java.util.HashSet<java.awt.geom.Rectangle2D>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.awt.geom.Rectangle2D> defaultValueJsonDeserialized = new java.util.HashSet<java.awt.geom.Rectangle2D>(jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue1 = new java.util.HashSet<java.awt.geom.Rectangle2D>(java.util.Arrays.asList((java.awt.geom.Rectangle2D) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue1JsonDeserialized = new java.util.HashSet<java.awt.geom.Rectangle2D>(jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue2 = new java.util.HashSet<java.awt.geom.Rectangle2D>(java.util.Arrays.asList(new java.awt.geom.Rectangle2D.Float()));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue2JsonDeserialized = new java.util.HashSet<java.awt.geom.Rectangle2D>(jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue3 = new java.util.HashSet<java.awt.geom.Rectangle2D>(java.util.Arrays.asList(new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue3JsonDeserialized = new java.util.HashSet<java.awt.geom.Rectangle2D>(jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue4 = new java.util.HashSet<java.awt.geom.Rectangle2D>(java.util.Arrays.asList(new java.awt.geom.Rectangle2D.Float(), new java.awt.Rectangle(Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Rectangle(-1000000000, -1000000000, 1000000000, 1000000000), new java.awt.geom.Rectangle2D.Float(Float.MIN_VALUE, Float.MIN_VALUE, Float.MAX_VALUE, Float.MAX_VALUE), new java.awt.geom.Rectangle2D.Float(-1.0000001f, -1.0000001f, 1.0000001f, 1.0000001f), new java.awt.geom.Rectangle2D.Double(Double.MIN_VALUE, Double.MIN_VALUE, Double.MAX_VALUE, Double.MAX_VALUE), new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue4JsonDeserialized = new java.util.HashSet<java.awt.geom.Rectangle2D>(jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue5 = new java.util.HashSet<java.awt.geom.Rectangle2D>(java.util.Arrays.asList((java.awt.geom.Rectangle2D) null, new java.awt.geom.Rectangle2D.Float(), new java.awt.Rectangle(Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Rectangle(-1000000000, -1000000000, 1000000000, 1000000000), new java.awt.geom.Rectangle2D.Float(Float.MIN_VALUE, Float.MIN_VALUE, Float.MAX_VALUE, Float.MAX_VALUE), new java.awt.geom.Rectangle2D.Float(-1.0000001f, -1.0000001f, 1.0000001f, 1.0000001f), new java.awt.geom.Rectangle2D.Double(Double.MIN_VALUE, Double.MIN_VALUE, Double.MAX_VALUE, Double.MAX_VALUE), new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue5JsonDeserialized = new java.util.HashSet<java.awt.geom.Rectangle2D>(jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Rectangle/OneSetOfOneRectanglesDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Rectangle/OneSetOfOneRectanglesDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Rectangle;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfOneRectanglesDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.awt.geom.Rectangle2D> defaultValue = new java.util.HashSet<java.awt.geom.Rectangle2D>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.awt.geom.Rectangle2D> defaultValueJsonDeserialized = new java.util.HashSet<java.awt.geom.Rectangle2D>(jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue1 = new java.util.HashSet<java.awt.geom.Rectangle2D>(java.util.Arrays.asList(new java.awt.geom.Rectangle2D.Float()));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue1JsonDeserialized = new java.util.HashSet<java.awt.geom.Rectangle2D>(jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue2 = new java.util.HashSet<java.awt.geom.Rectangle2D>(java.util.Arrays.asList(new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue2JsonDeserialized = new java.util.HashSet<java.awt.geom.Rectangle2D>(jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue3 = new java.util.HashSet<java.awt.geom.Rectangle2D>(java.util.Arrays.asList(new java.awt.geom.Rectangle2D.Float(), new java.awt.Rectangle(Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE), new java.awt.Rectangle(-1000000000, -1000000000, 1000000000, 1000000000), new java.awt.geom.Rectangle2D.Float(Float.MIN_VALUE, Float.MIN_VALUE, Float.MAX_VALUE, Float.MAX_VALUE), new java.awt.geom.Rectangle2D.Float(-1.0000001f, -1.0000001f, 1.0000001f, 1.0000001f), new java.awt.geom.Rectangle2D.Double(Double.MIN_VALUE, Double.MIN_VALUE, Double.MAX_VALUE, Double.MAX_VALUE), new java.awt.geom.Rectangle2D.Double(-1.000000000000001, -1.000000000000001, 1.000000000000001, 1.000000000000001)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.awt.geom.Rectangle2D> borderValue3JsonDeserialized = new java.util.HashSet<java.awt.geom.Rectangle2D>(jsonSerialization.deserializeList(java.awt.geom.Rectangle2D.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.RectangleAsserts.assertOneSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/String/NullableArrayOfNullableStringsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/String/NullableArrayOfNullableStringsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.String;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfNullableStringsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final String[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final String[] defaultValueJsonDeserialized = jsonSerialization.deserialize(String[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final String[] borderValue1 = new String[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final String[] borderValue1JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final String[] borderValue2 = new String[] { "" };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final String[] borderValue2JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final String[] borderValue3 = new String[] { "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100" };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final String[] borderValue3JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final String[] borderValue4 = new String[] { "", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100" };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final String[] borderValue4JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final String[] borderValue5 = new String[] { null, "", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100" };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final String[] borderValue5JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/String/NullableArrayOfOneStringsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/String/NullableArrayOfOneStringsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.String;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfOneStringsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final String[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final String[] defaultValueJsonDeserialized = jsonSerialization.deserialize(String[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final String[] borderValue1 = new String[] { "" };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final String[] borderValue1JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final String[] borderValue2 = new String[] { "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100" };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final String[] borderValue2JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final String[] borderValue3 = new String[] { "", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100" };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final String[] borderValue3JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/String/NullableListOfNullableStringsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/String/NullableListOfNullableStringsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.String;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfNullableStringsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<String> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<String> defaultValueJsonDeserialized = jsonSerialization.deserializeList(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<String> borderValue1 = new java.util.ArrayList<String>(java.util.Arrays.asList((String) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<String> borderValue1JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<String> borderValue2 = new java.util.ArrayList<String>(java.util.Arrays.asList(""));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<String> borderValue2JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<String> borderValue3 = new java.util.ArrayList<String>(java.util.Arrays.asList("\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<String> borderValue3JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<String> borderValue4 = new java.util.ArrayList<String>(java.util.Arrays.asList("", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<String> borderValue4JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<String> borderValue5 = new java.util.ArrayList<String>(java.util.Arrays.asList((String) null, "", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<String> borderValue5JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/String/NullableListOfOneStringsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/String/NullableListOfOneStringsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.String;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfOneStringsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<String> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<String> defaultValueJsonDeserialized = jsonSerialization.deserializeList(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<String> borderValue1 = new java.util.ArrayList<String>(java.util.Arrays.asList(""));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<String> borderValue1JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<String> borderValue2 = new java.util.ArrayList<String>(java.util.Arrays.asList("\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<String> borderValue2JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<String> borderValue3 = new java.util.ArrayList<String>(java.util.Arrays.asList("", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<String> borderValue3JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/String/NullableSetOfNullableStringsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/String/NullableSetOfNullableStringsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.String;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfNullableStringsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<String> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<String> defaultValueJsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<String> borderValue1 = new java.util.HashSet<String>(java.util.Arrays.asList((String) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<String> borderValue1JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<String> borderValue2 = new java.util.HashSet<String>(java.util.Arrays.asList(""));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<String> borderValue2JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<String> borderValue3 = new java.util.HashSet<String>(java.util.Arrays.asList("\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<String> borderValue3JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<String> borderValue4 = new java.util.HashSet<String>(java.util.Arrays.asList("", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<String> borderValue4JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<String> borderValue5 = new java.util.HashSet<String>(java.util.Arrays.asList((String) null, "", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<String> borderValue5JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/String/NullableSetOfOneStringsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/String/NullableSetOfOneStringsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.String;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfOneStringsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<String> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<String> defaultValueJsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<String> borderValue1 = new java.util.HashSet<String>(java.util.Arrays.asList(""));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<String> borderValue1JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<String> borderValue2 = new java.util.HashSet<String>(java.util.Arrays.asList("\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<String> borderValue2JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<String> borderValue3 = new java.util.HashSet<String>(java.util.Arrays.asList("", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<String> borderValue3JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/String/NullableStringDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/String/NullableStringDefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.String;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableStringDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final String defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final String defaultValueJsonDeserialized = jsonSerialization.deserialize(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final String borderValue1 = "";
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final String borderValue1JsonDeserialized = jsonSerialization.deserialize(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final String borderValue2 = "\"";
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final String borderValue2JsonDeserialized = jsonSerialization.deserialize(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final String borderValue3 = "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}";
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final String borderValue3JsonDeserialized = jsonSerialization.deserialize(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final String borderValue4 = "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100";
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final String borderValue4JsonDeserialized = jsonSerialization.deserialize(String.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/String/OneArrayOfNullableStringsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/String/OneArrayOfNullableStringsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.String;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfNullableStringsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final String[] defaultValue = new String[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final String[] defaultValueJsonDeserialized = jsonSerialization.deserialize(String[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final String[] borderValue1 = new String[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final String[] borderValue1JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final String[] borderValue2 = new String[] { "" };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final String[] borderValue2JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final String[] borderValue3 = new String[] { "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100" };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final String[] borderValue3JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final String[] borderValue4 = new String[] { "", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100" };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final String[] borderValue4JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final String[] borderValue5 = new String[] { null, "", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100" };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final String[] borderValue5JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/String/OneArrayOfOneStringsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/String/OneArrayOfOneStringsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.String;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfOneStringsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final String[] defaultValue = new String[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final String[] defaultValueJsonDeserialized = jsonSerialization.deserialize(String[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final String[] borderValue1 = new String[] { "" };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final String[] borderValue1JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final String[] borderValue2 = new String[] { "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100" };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final String[] borderValue2JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final String[] borderValue3 = new String[] { "", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100" };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final String[] borderValue3JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/String/OneListOfNullableStringsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/String/OneListOfNullableStringsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.String;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfNullableStringsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<String> defaultValue = new java.util.ArrayList<String>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<String> defaultValueJsonDeserialized = jsonSerialization.deserializeList(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<String> borderValue1 = new java.util.ArrayList<String>(java.util.Arrays.asList((String) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<String> borderValue1JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<String> borderValue2 = new java.util.ArrayList<String>(java.util.Arrays.asList(""));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<String> borderValue2JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<String> borderValue3 = new java.util.ArrayList<String>(java.util.Arrays.asList("\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<String> borderValue3JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<String> borderValue4 = new java.util.ArrayList<String>(java.util.Arrays.asList("", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<String> borderValue4JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<String> borderValue5 = new java.util.ArrayList<String>(java.util.Arrays.asList((String) null, "", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<String> borderValue5JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/String/OneListOfOneStringsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/String/OneListOfOneStringsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.String;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfOneStringsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<String> defaultValue = new java.util.ArrayList<String>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<String> defaultValueJsonDeserialized = jsonSerialization.deserializeList(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<String> borderValue1 = new java.util.ArrayList<String>(java.util.Arrays.asList(""));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<String> borderValue1JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<String> borderValue2 = new java.util.ArrayList<String>(java.util.Arrays.asList("\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<String> borderValue2JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<String> borderValue3 = new java.util.ArrayList<String>(java.util.Arrays.asList("", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<String> borderValue3JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/String/OneSetOfNullableStringsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/String/OneSetOfNullableStringsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.String;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfNullableStringsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<String> defaultValue = new java.util.HashSet<String>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<String> defaultValueJsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<String> borderValue1 = new java.util.HashSet<String>(java.util.Arrays.asList((String) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<String> borderValue1JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<String> borderValue2 = new java.util.HashSet<String>(java.util.Arrays.asList(""));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<String> borderValue2JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<String> borderValue3 = new java.util.HashSet<String>(java.util.Arrays.asList("\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<String> borderValue3JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<String> borderValue4 = new java.util.HashSet<String>(java.util.Arrays.asList("", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<String> borderValue4JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<String> borderValue5 = new java.util.HashSet<String>(java.util.Arrays.asList((String) null, "", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<String> borderValue5JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/String/OneSetOfOneStringsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/String/OneSetOfOneStringsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.String;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfOneStringsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<String> defaultValue = new java.util.HashSet<String>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<String> defaultValueJsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<String> borderValue1 = new java.util.HashSet<String>(java.util.Arrays.asList(""));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<String> borderValue1JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<String> borderValue2 = new java.util.HashSet<String>(java.util.Arrays.asList("\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<String> borderValue2JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<String> borderValue3 = new java.util.HashSet<String>(java.util.Arrays.asList("", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<String> borderValue3JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/String/OneStringDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/String/OneStringDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.String;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneStringDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final String defaultValue = "";
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final String defaultValueJsonDeserialized = jsonSerialization.deserialize(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final String borderValue1 = "\"";
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final String borderValue1JsonDeserialized = jsonSerialization.deserialize(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final String borderValue2 = "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}";
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final String borderValue2JsonDeserialized = jsonSerialization.deserialize(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final String borderValue3 = "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100";
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final String borderValue3JsonDeserialized = jsonSerialization.deserialize(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringAsserts.assertOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/StringWithMaxLengthOf9/NullableArrayOfNullableStringsWithMaxLengthOf9DefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/StringWithMaxLengthOf9/NullableArrayOfNullableStringsWithMaxLengthOf9DefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.StringWithMaxLengthOf9;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfNullableStringsWithMaxLengthOf9DefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final String[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final String[] defaultValueJsonDeserialized = jsonSerialization.deserialize(String[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final String[] borderValue1 = new String[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final String[] borderValue1JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final String[] borderValue2 = new String[] { "" };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final String[] borderValue2JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final String[] borderValue3 = new String[] { "xxxxxxxxx" };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final String[] borderValue3JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final String[] borderValue4 = new String[] { "", "\"", "'/\\[](){}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t", "xxxxxxxxx" };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final String[] borderValue4JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final String[] borderValue5 = new String[] { null, "", "\"", "'/\\[](){}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t", "xxxxxxxxx" };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final String[] borderValue5JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/StringWithMaxLengthOf9/NullableArrayOfOneStringsWithMaxLengthOf9DefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/StringWithMaxLengthOf9/NullableArrayOfOneStringsWithMaxLengthOf9DefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.StringWithMaxLengthOf9;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfOneStringsWithMaxLengthOf9DefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final String[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final String[] defaultValueJsonDeserialized = jsonSerialization.deserialize(String[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final String[] borderValue1 = new String[] { "" };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final String[] borderValue1JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final String[] borderValue2 = new String[] { "xxxxxxxxx" };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final String[] borderValue2JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final String[] borderValue3 = new String[] { "", "\"", "'/\\[](){}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t", "xxxxxxxxx" };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final String[] borderValue3JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/StringWithMaxLengthOf9/NullableListOfNullableStringsWithMaxLengthOf9DefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/StringWithMaxLengthOf9/NullableListOfNullableStringsWithMaxLengthOf9DefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.StringWithMaxLengthOf9;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfNullableStringsWithMaxLengthOf9DefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<String> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<String> defaultValueJsonDeserialized = jsonSerialization.deserializeList(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<String> borderValue1 = new java.util.ArrayList<String>(java.util.Arrays.asList((String) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<String> borderValue1JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<String> borderValue2 = new java.util.ArrayList<String>(java.util.Arrays.asList(""));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<String> borderValue2JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<String> borderValue3 = new java.util.ArrayList<String>(java.util.Arrays.asList("xxxxxxxxx"));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<String> borderValue3JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<String> borderValue4 = new java.util.ArrayList<String>(java.util.Arrays.asList("", "\"", "'/\\[](){}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t", "xxxxxxxxx"));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<String> borderValue4JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<String> borderValue5 = new java.util.ArrayList<String>(java.util.Arrays.asList((String) null, "", "\"", "'/\\[](){}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t", "xxxxxxxxx"));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<String> borderValue5JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/StringWithMaxLengthOf9/NullableListOfOneStringsWithMaxLengthOf9DefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/StringWithMaxLengthOf9/NullableListOfOneStringsWithMaxLengthOf9DefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.StringWithMaxLengthOf9;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfOneStringsWithMaxLengthOf9DefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<String> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<String> defaultValueJsonDeserialized = jsonSerialization.deserializeList(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<String> borderValue1 = new java.util.ArrayList<String>(java.util.Arrays.asList(""));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<String> borderValue1JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<String> borderValue2 = new java.util.ArrayList<String>(java.util.Arrays.asList("xxxxxxxxx"));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<String> borderValue2JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<String> borderValue3 = new java.util.ArrayList<String>(java.util.Arrays.asList("", "\"", "'/\\[](){}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t", "xxxxxxxxx"));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<String> borderValue3JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/StringWithMaxLengthOf9/NullableSetOfNullableStringsWithMaxLengthOf9DefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/StringWithMaxLengthOf9/NullableSetOfNullableStringsWithMaxLengthOf9DefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.StringWithMaxLengthOf9;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfNullableStringsWithMaxLengthOf9DefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<String> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<String> defaultValueJsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<String> borderValue1 = new java.util.HashSet<String>(java.util.Arrays.asList((String) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<String> borderValue1JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<String> borderValue2 = new java.util.HashSet<String>(java.util.Arrays.asList(""));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<String> borderValue2JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<String> borderValue3 = new java.util.HashSet<String>(java.util.Arrays.asList("xxxxxxxxx"));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<String> borderValue3JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<String> borderValue4 = new java.util.HashSet<String>(java.util.Arrays.asList("", "\"", "'/\\[](){}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t", "xxxxxxxxx"));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<String> borderValue4JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<String> borderValue5 = new java.util.HashSet<String>(java.util.Arrays.asList((String) null, "", "\"", "'/\\[](){}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t", "xxxxxxxxx"));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<String> borderValue5JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/StringWithMaxLengthOf9/NullableSetOfOneStringsWithMaxLengthOf9DefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/StringWithMaxLengthOf9/NullableSetOfOneStringsWithMaxLengthOf9DefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.StringWithMaxLengthOf9;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfOneStringsWithMaxLengthOf9DefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<String> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<String> defaultValueJsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<String> borderValue1 = new java.util.HashSet<String>(java.util.Arrays.asList(""));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<String> borderValue1JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<String> borderValue2 = new java.util.HashSet<String>(java.util.Arrays.asList("xxxxxxxxx"));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<String> borderValue2JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<String> borderValue3 = new java.util.HashSet<String>(java.util.Arrays.asList("", "\"", "'/\\[](){}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t", "xxxxxxxxx"));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<String> borderValue3JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/StringWithMaxLengthOf9/NullableStringWithMaxLengthOf9DefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/StringWithMaxLengthOf9/NullableStringWithMaxLengthOf9DefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.StringWithMaxLengthOf9;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableStringWithMaxLengthOf9DefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final String defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final String defaultValueJsonDeserialized = jsonSerialization.deserialize(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final String borderValue1 = "";
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final String borderValue1JsonDeserialized = jsonSerialization.deserialize(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final String borderValue2 = "\"";
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final String borderValue2JsonDeserialized = jsonSerialization.deserialize(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final String borderValue3 = "'/\\[](){}";
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final String borderValue3JsonDeserialized = jsonSerialization.deserialize(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final String borderValue4 = "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t";
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final String borderValue4JsonDeserialized = jsonSerialization.deserialize(String.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final String borderValue5 = "xxxxxxxxx";
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final String borderValue5JsonDeserialized = jsonSerialization.deserialize(String.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/StringWithMaxLengthOf9/OneArrayOfNullableStringsWithMaxLengthOf9DefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/StringWithMaxLengthOf9/OneArrayOfNullableStringsWithMaxLengthOf9DefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.StringWithMaxLengthOf9;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfNullableStringsWithMaxLengthOf9DefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final String[] defaultValue = new String[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final String[] defaultValueJsonDeserialized = jsonSerialization.deserialize(String[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final String[] borderValue1 = new String[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final String[] borderValue1JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final String[] borderValue2 = new String[] { "" };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final String[] borderValue2JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final String[] borderValue3 = new String[] { "xxxxxxxxx" };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final String[] borderValue3JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final String[] borderValue4 = new String[] { "", "\"", "'/\\[](){}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t", "xxxxxxxxx" };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final String[] borderValue4JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final String[] borderValue5 = new String[] { null, "", "\"", "'/\\[](){}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t", "xxxxxxxxx" };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final String[] borderValue5JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/StringWithMaxLengthOf9/OneArrayOfOneStringsWithMaxLengthOf9DefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/StringWithMaxLengthOf9/OneArrayOfOneStringsWithMaxLengthOf9DefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.StringWithMaxLengthOf9;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfOneStringsWithMaxLengthOf9DefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final String[] defaultValue = new String[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final String[] defaultValueJsonDeserialized = jsonSerialization.deserialize(String[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final String[] borderValue1 = new String[] { "" };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final String[] borderValue1JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final String[] borderValue2 = new String[] { "xxxxxxxxx" };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final String[] borderValue2JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final String[] borderValue3 = new String[] { "", "\"", "'/\\[](){}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t", "xxxxxxxxx" };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final String[] borderValue3JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/StringWithMaxLengthOf9/OneListOfNullableStringsWithMaxLengthOf9DefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/StringWithMaxLengthOf9/OneListOfNullableStringsWithMaxLengthOf9DefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.StringWithMaxLengthOf9;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfNullableStringsWithMaxLengthOf9DefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<String> defaultValue = new java.util.ArrayList<String>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<String> defaultValueJsonDeserialized = jsonSerialization.deserializeList(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<String> borderValue1 = new java.util.ArrayList<String>(java.util.Arrays.asList((String) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<String> borderValue1JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<String> borderValue2 = new java.util.ArrayList<String>(java.util.Arrays.asList(""));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<String> borderValue2JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<String> borderValue3 = new java.util.ArrayList<String>(java.util.Arrays.asList("xxxxxxxxx"));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<String> borderValue3JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<String> borderValue4 = new java.util.ArrayList<String>(java.util.Arrays.asList("", "\"", "'/\\[](){}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t", "xxxxxxxxx"));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<String> borderValue4JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<String> borderValue5 = new java.util.ArrayList<String>(java.util.Arrays.asList((String) null, "", "\"", "'/\\[](){}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t", "xxxxxxxxx"));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<String> borderValue5JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/StringWithMaxLengthOf9/OneListOfOneStringsWithMaxLengthOf9DefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/StringWithMaxLengthOf9/OneListOfOneStringsWithMaxLengthOf9DefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.StringWithMaxLengthOf9;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfOneStringsWithMaxLengthOf9DefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<String> defaultValue = new java.util.ArrayList<String>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<String> defaultValueJsonDeserialized = jsonSerialization.deserializeList(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<String> borderValue1 = new java.util.ArrayList<String>(java.util.Arrays.asList(""));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<String> borderValue1JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<String> borderValue2 = new java.util.ArrayList<String>(java.util.Arrays.asList("xxxxxxxxx"));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<String> borderValue2JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<String> borderValue3 = new java.util.ArrayList<String>(java.util.Arrays.asList("", "\"", "'/\\[](){}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t", "xxxxxxxxx"));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<String> borderValue3JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/StringWithMaxLengthOf9/OneSetOfNullableStringsWithMaxLengthOf9DefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/StringWithMaxLengthOf9/OneSetOfNullableStringsWithMaxLengthOf9DefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.StringWithMaxLengthOf9;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfNullableStringsWithMaxLengthOf9DefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<String> defaultValue = new java.util.HashSet<String>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<String> defaultValueJsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<String> borderValue1 = new java.util.HashSet<String>(java.util.Arrays.asList((String) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<String> borderValue1JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<String> borderValue2 = new java.util.HashSet<String>(java.util.Arrays.asList(""));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<String> borderValue2JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<String> borderValue3 = new java.util.HashSet<String>(java.util.Arrays.asList("xxxxxxxxx"));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<String> borderValue3JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<String> borderValue4 = new java.util.HashSet<String>(java.util.Arrays.asList("", "\"", "'/\\[](){}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t", "xxxxxxxxx"));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<String> borderValue4JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<String> borderValue5 = new java.util.HashSet<String>(java.util.Arrays.asList((String) null, "", "\"", "'/\\[](){}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t", "xxxxxxxxx"));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<String> borderValue5JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/StringWithMaxLengthOf9/OneSetOfOneStringsWithMaxLengthOf9DefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/StringWithMaxLengthOf9/OneSetOfOneStringsWithMaxLengthOf9DefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.StringWithMaxLengthOf9;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfOneStringsWithMaxLengthOf9DefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<String> defaultValue = new java.util.HashSet<String>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<String> defaultValueJsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<String> borderValue1 = new java.util.HashSet<String>(java.util.Arrays.asList(""));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<String> borderValue1JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<String> borderValue2 = new java.util.HashSet<String>(java.util.Arrays.asList("xxxxxxxxx"));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<String> borderValue2JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<String> borderValue3 = new java.util.HashSet<String>(java.util.Arrays.asList("", "\"", "'/\\[](){}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t", "xxxxxxxxx"));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<String> borderValue3JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/StringWithMaxLengthOf9/OneStringWithMaxLengthOf9DefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/StringWithMaxLengthOf9/OneStringWithMaxLengthOf9DefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.StringWithMaxLengthOf9;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneStringWithMaxLengthOf9DefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final String defaultValue = "";
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final String defaultValueJsonDeserialized = jsonSerialization.deserialize(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final String borderValue1 = "\"";
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final String borderValue1JsonDeserialized = jsonSerialization.deserialize(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final String borderValue2 = "'/\\[](){}";
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final String borderValue2JsonDeserialized = jsonSerialization.deserialize(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final String borderValue3 = "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t";
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final String borderValue3JsonDeserialized = jsonSerialization.deserialize(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final String borderValue4 = "xxxxxxxxx";
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final String borderValue4JsonDeserialized = jsonSerialization.deserialize(String.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.StringWithMaxLengthOf9Asserts.assertOneEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Text/NullableArrayOfNullableTextsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Text/NullableArrayOfNullableTextsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Text;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfNullableTextsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final String[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final String[] defaultValueJsonDeserialized = jsonSerialization.deserialize(String[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final String[] borderValue1 = new String[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final String[] borderValue1JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final String[] borderValue2 = new String[] { "" };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final String[] borderValue2JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final String[] borderValue3 = new String[] { "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100" };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final String[] borderValue3JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final String[] borderValue4 = new String[] { "", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100" };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final String[] borderValue4JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final String[] borderValue5 = new String[] { null, "", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100" };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final String[] borderValue5JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Text/NullableArrayOfOneTextsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Text/NullableArrayOfOneTextsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Text;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfOneTextsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final String[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final String[] defaultValueJsonDeserialized = jsonSerialization.deserialize(String[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final String[] borderValue1 = new String[] { "" };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final String[] borderValue1JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final String[] borderValue2 = new String[] { "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100" };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final String[] borderValue2JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final String[] borderValue3 = new String[] { "", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100" };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final String[] borderValue3JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Text/NullableListOfNullableTextsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Text/NullableListOfNullableTextsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Text;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfNullableTextsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<String> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<String> defaultValueJsonDeserialized = jsonSerialization.deserializeList(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<String> borderValue1 = new java.util.ArrayList<String>(java.util.Arrays.asList((String) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<String> borderValue1JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<String> borderValue2 = new java.util.ArrayList<String>(java.util.Arrays.asList(""));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<String> borderValue2JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<String> borderValue3 = new java.util.ArrayList<String>(java.util.Arrays.asList("\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<String> borderValue3JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<String> borderValue4 = new java.util.ArrayList<String>(java.util.Arrays.asList("", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<String> borderValue4JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<String> borderValue5 = new java.util.ArrayList<String>(java.util.Arrays.asList((String) null, "", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<String> borderValue5JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Text/NullableListOfOneTextsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Text/NullableListOfOneTextsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Text;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfOneTextsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<String> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<String> defaultValueJsonDeserialized = jsonSerialization.deserializeList(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<String> borderValue1 = new java.util.ArrayList<String>(java.util.Arrays.asList(""));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<String> borderValue1JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<String> borderValue2 = new java.util.ArrayList<String>(java.util.Arrays.asList("\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<String> borderValue2JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<String> borderValue3 = new java.util.ArrayList<String>(java.util.Arrays.asList("", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<String> borderValue3JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Text/NullableSetOfNullableTextsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Text/NullableSetOfNullableTextsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Text;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfNullableTextsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<String> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<String> defaultValueJsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<String> borderValue1 = new java.util.HashSet<String>(java.util.Arrays.asList((String) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<String> borderValue1JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<String> borderValue2 = new java.util.HashSet<String>(java.util.Arrays.asList(""));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<String> borderValue2JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<String> borderValue3 = new java.util.HashSet<String>(java.util.Arrays.asList("\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<String> borderValue3JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<String> borderValue4 = new java.util.HashSet<String>(java.util.Arrays.asList("", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<String> borderValue4JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<String> borderValue5 = new java.util.HashSet<String>(java.util.Arrays.asList((String) null, "", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<String> borderValue5JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Text/NullableSetOfOneTextsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Text/NullableSetOfOneTextsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Text;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfOneTextsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<String> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<String> defaultValueJsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<String> borderValue1 = new java.util.HashSet<String>(java.util.Arrays.asList(""));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<String> borderValue1JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<String> borderValue2 = new java.util.HashSet<String>(java.util.Arrays.asList("\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<String> borderValue2JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<String> borderValue3 = new java.util.HashSet<String>(java.util.Arrays.asList("", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<String> borderValue3JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Text/NullableTextDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Text/NullableTextDefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Text;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableTextDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final String defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final String defaultValueJsonDeserialized = jsonSerialization.deserialize(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final String borderValue1 = "";
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final String borderValue1JsonDeserialized = jsonSerialization.deserialize(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final String borderValue2 = "\"";
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final String borderValue2JsonDeserialized = jsonSerialization.deserialize(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final String borderValue3 = "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}";
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final String borderValue3JsonDeserialized = jsonSerialization.deserialize(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final String borderValue4 = "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100";
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final String borderValue4JsonDeserialized = jsonSerialization.deserialize(String.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Text/OneArrayOfNullableTextsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Text/OneArrayOfNullableTextsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Text;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfNullableTextsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final String[] defaultValue = new String[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final String[] defaultValueJsonDeserialized = jsonSerialization.deserialize(String[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final String[] borderValue1 = new String[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final String[] borderValue1JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final String[] borderValue2 = new String[] { "" };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final String[] borderValue2JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final String[] borderValue3 = new String[] { "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100" };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final String[] borderValue3JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final String[] borderValue4 = new String[] { "", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100" };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final String[] borderValue4JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final String[] borderValue5 = new String[] { null, "", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100" };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final String[] borderValue5JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Text/OneArrayOfOneTextsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Text/OneArrayOfOneTextsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Text;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfOneTextsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final String[] defaultValue = new String[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final String[] defaultValueJsonDeserialized = jsonSerialization.deserialize(String[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final String[] borderValue1 = new String[] { "" };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final String[] borderValue1JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final String[] borderValue2 = new String[] { "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100" };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final String[] borderValue2JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final String[] borderValue3 = new String[] { "", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100" };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final String[] borderValue3JsonDeserialized = jsonSerialization.deserialize(String[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Text/OneListOfNullableTextsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Text/OneListOfNullableTextsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Text;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfNullableTextsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<String> defaultValue = new java.util.ArrayList<String>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<String> defaultValueJsonDeserialized = jsonSerialization.deserializeList(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<String> borderValue1 = new java.util.ArrayList<String>(java.util.Arrays.asList((String) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<String> borderValue1JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<String> borderValue2 = new java.util.ArrayList<String>(java.util.Arrays.asList(""));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<String> borderValue2JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<String> borderValue3 = new java.util.ArrayList<String>(java.util.Arrays.asList("\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<String> borderValue3JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<String> borderValue4 = new java.util.ArrayList<String>(java.util.Arrays.asList("", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<String> borderValue4JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<String> borderValue5 = new java.util.ArrayList<String>(java.util.Arrays.asList((String) null, "", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<String> borderValue5JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Text/OneListOfOneTextsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Text/OneListOfOneTextsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Text;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfOneTextsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<String> defaultValue = new java.util.ArrayList<String>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<String> defaultValueJsonDeserialized = jsonSerialization.deserializeList(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<String> borderValue1 = new java.util.ArrayList<String>(java.util.Arrays.asList(""));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<String> borderValue1JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<String> borderValue2 = new java.util.ArrayList<String>(java.util.Arrays.asList("\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<String> borderValue2JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<String> borderValue3 = new java.util.ArrayList<String>(java.util.Arrays.asList("", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<String> borderValue3JsonDeserialized = jsonSerialization.deserializeList(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Text/OneSetOfNullableTextsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Text/OneSetOfNullableTextsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Text;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfNullableTextsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<String> defaultValue = new java.util.HashSet<String>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<String> defaultValueJsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<String> borderValue1 = new java.util.HashSet<String>(java.util.Arrays.asList((String) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<String> borderValue1JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<String> borderValue2 = new java.util.HashSet<String>(java.util.Arrays.asList(""));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<String> borderValue2JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<String> borderValue3 = new java.util.HashSet<String>(java.util.Arrays.asList("\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<String> borderValue3JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<String> borderValue4 = new java.util.HashSet<String>(java.util.Arrays.asList("", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<String> borderValue4JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<String> borderValue5 = new java.util.HashSet<String>(java.util.Arrays.asList((String) null, "", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<String> borderValue5JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Text/OneSetOfOneTextsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Text/OneSetOfOneTextsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Text;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfOneTextsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<String> defaultValue = new java.util.HashSet<String>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<String> defaultValueJsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<String> borderValue1 = new java.util.HashSet<String>(java.util.Arrays.asList(""));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<String> borderValue1JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<String> borderValue2 = new java.util.HashSet<String>(java.util.Arrays.asList("\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<String> borderValue2JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<String> borderValue3 = new java.util.HashSet<String>(java.util.Arrays.asList("", "\"", "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}", "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100"));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<String> borderValue3JsonDeserialized = new java.util.HashSet<String>(jsonSerialization.deserializeList(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Text/OneTextDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Text/OneTextDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Text;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneTextDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final String defaultValue = "";
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final String defaultValueJsonDeserialized = jsonSerialization.deserialize(String.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final String borderValue1 = "\"";
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final String borderValue1JsonDeserialized = jsonSerialization.deserialize(String.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final String borderValue2 = "Quote: \", Solidus /, Backslash: \\, Aphos: ', Brackets: [] () {}";
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final String borderValue2JsonDeserialized = jsonSerialization.deserialize(String.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final String borderValue3 = "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u0080\u0081\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF\u0100";
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final String borderValue3JsonDeserialized = jsonSerialization.deserialize(String.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TextAsserts.assertOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Timestamp/NullableArrayOfNullableTimestampsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Timestamp/NullableArrayOfNullableTimestampsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Timestamp;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfNullableTimestampsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final org.joda.time.DateTime[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final org.joda.time.DateTime[] defaultValueJsonDeserialized = jsonSerialization.deserialize(org.joda.time.DateTime[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final org.joda.time.DateTime[] borderValue1 = new org.joda.time.DateTime[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final org.joda.time.DateTime[] borderValue1JsonDeserialized = jsonSerialization.deserialize(org.joda.time.DateTime[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final org.joda.time.DateTime[] borderValue2 = new org.joda.time.DateTime[] { org.joda.time.DateTime.now() };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final org.joda.time.DateTime[] borderValue2JsonDeserialized = jsonSerialization.deserialize(org.joda.time.DateTime[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final org.joda.time.DateTime[] borderValue3 = new org.joda.time.DateTime[] { new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L) };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final org.joda.time.DateTime[] borderValue3JsonDeserialized = jsonSerialization.deserialize(org.joda.time.DateTime[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final org.joda.time.DateTime[] borderValue4 = new org.joda.time.DateTime[] { org.joda.time.DateTime.now(), new org.joda.time.DateTime(0), new org.joda.time.DateTime(1, 1, 1, 0, 0, org.joda.time.DateTimeZone.UTC), new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L) };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final org.joda.time.DateTime[] borderValue4JsonDeserialized = jsonSerialization.deserialize(org.joda.time.DateTime[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final org.joda.time.DateTime[] borderValue5 = new org.joda.time.DateTime[] { null, org.joda.time.DateTime.now(), new org.joda.time.DateTime(0), new org.joda.time.DateTime(1, 1, 1, 0, 0, org.joda.time.DateTimeZone.UTC), new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L) };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final org.joda.time.DateTime[] borderValue5JsonDeserialized = jsonSerialization.deserialize(org.joda.time.DateTime[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Timestamp/NullableArrayOfOneTimestampsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Timestamp/NullableArrayOfOneTimestampsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Timestamp;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfOneTimestampsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final org.joda.time.DateTime[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final org.joda.time.DateTime[] defaultValueJsonDeserialized = jsonSerialization.deserialize(org.joda.time.DateTime[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final org.joda.time.DateTime[] borderValue1 = new org.joda.time.DateTime[] { org.joda.time.DateTime.now() };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final org.joda.time.DateTime[] borderValue1JsonDeserialized = jsonSerialization.deserialize(org.joda.time.DateTime[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final org.joda.time.DateTime[] borderValue2 = new org.joda.time.DateTime[] { new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L) };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final org.joda.time.DateTime[] borderValue2JsonDeserialized = jsonSerialization.deserialize(org.joda.time.DateTime[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final org.joda.time.DateTime[] borderValue3 = new org.joda.time.DateTime[] { org.joda.time.DateTime.now(), new org.joda.time.DateTime(0), new org.joda.time.DateTime(1, 1, 1, 0, 0, org.joda.time.DateTimeZone.UTC), new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L) };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final org.joda.time.DateTime[] borderValue3JsonDeserialized = jsonSerialization.deserialize(org.joda.time.DateTime[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Timestamp/NullableListOfNullableTimestampsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Timestamp/NullableListOfNullableTimestampsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Timestamp;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfNullableTimestampsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<org.joda.time.DateTime> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<org.joda.time.DateTime> defaultValueJsonDeserialized = jsonSerialization.deserializeList(org.joda.time.DateTime.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<org.joda.time.DateTime> borderValue1 = new java.util.ArrayList<org.joda.time.DateTime>(java.util.Arrays.asList((org.joda.time.DateTime) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<org.joda.time.DateTime> borderValue1JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<org.joda.time.DateTime> borderValue2 = new java.util.ArrayList<org.joda.time.DateTime>(java.util.Arrays.asList(org.joda.time.DateTime.now()));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<org.joda.time.DateTime> borderValue2JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<org.joda.time.DateTime> borderValue3 = new java.util.ArrayList<org.joda.time.DateTime>(java.util.Arrays.asList(new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<org.joda.time.DateTime> borderValue3JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<org.joda.time.DateTime> borderValue4 = new java.util.ArrayList<org.joda.time.DateTime>(java.util.Arrays.asList(org.joda.time.DateTime.now(), new org.joda.time.DateTime(0), new org.joda.time.DateTime(1, 1, 1, 0, 0, org.joda.time.DateTimeZone.UTC), new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L)));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<org.joda.time.DateTime> borderValue4JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<org.joda.time.DateTime> borderValue5 = new java.util.ArrayList<org.joda.time.DateTime>(java.util.Arrays.asList((org.joda.time.DateTime) null, org.joda.time.DateTime.now(), new org.joda.time.DateTime(0), new org.joda.time.DateTime(1, 1, 1, 0, 0, org.joda.time.DateTimeZone.UTC), new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L)));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<org.joda.time.DateTime> borderValue5JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Timestamp/NullableListOfOneTimestampsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Timestamp/NullableListOfOneTimestampsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Timestamp;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfOneTimestampsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<org.joda.time.DateTime> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<org.joda.time.DateTime> defaultValueJsonDeserialized = jsonSerialization.deserializeList(org.joda.time.DateTime.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<org.joda.time.DateTime> borderValue1 = new java.util.ArrayList<org.joda.time.DateTime>(java.util.Arrays.asList(org.joda.time.DateTime.now()));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<org.joda.time.DateTime> borderValue1JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<org.joda.time.DateTime> borderValue2 = new java.util.ArrayList<org.joda.time.DateTime>(java.util.Arrays.asList(new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<org.joda.time.DateTime> borderValue2JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<org.joda.time.DateTime> borderValue3 = new java.util.ArrayList<org.joda.time.DateTime>(java.util.Arrays.asList(org.joda.time.DateTime.now(), new org.joda.time.DateTime(0), new org.joda.time.DateTime(1, 1, 1, 0, 0, org.joda.time.DateTimeZone.UTC), new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<org.joda.time.DateTime> borderValue3JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Timestamp/NullableSetOfNullableTimestampsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Timestamp/NullableSetOfNullableTimestampsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Timestamp;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfNullableTimestampsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<org.joda.time.DateTime> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<org.joda.time.DateTime> defaultValueJsonDeserialized = new java.util.HashSet<org.joda.time.DateTime>(jsonSerialization.deserializeList(org.joda.time.DateTime.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<org.joda.time.DateTime> borderValue1 = new java.util.HashSet<org.joda.time.DateTime>(java.util.Arrays.asList((org.joda.time.DateTime) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<org.joda.time.DateTime> borderValue1JsonDeserialized = new java.util.HashSet<org.joda.time.DateTime>(jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<org.joda.time.DateTime> borderValue2 = new java.util.HashSet<org.joda.time.DateTime>(java.util.Arrays.asList(org.joda.time.DateTime.now()));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<org.joda.time.DateTime> borderValue2JsonDeserialized = new java.util.HashSet<org.joda.time.DateTime>(jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<org.joda.time.DateTime> borderValue3 = new java.util.HashSet<org.joda.time.DateTime>(java.util.Arrays.asList(new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<org.joda.time.DateTime> borderValue3JsonDeserialized = new java.util.HashSet<org.joda.time.DateTime>(jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<org.joda.time.DateTime> borderValue4 = new java.util.HashSet<org.joda.time.DateTime>(java.util.Arrays.asList(org.joda.time.DateTime.now(), new org.joda.time.DateTime(0), new org.joda.time.DateTime(1, 1, 1, 0, 0, org.joda.time.DateTimeZone.UTC), new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L)));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<org.joda.time.DateTime> borderValue4JsonDeserialized = new java.util.HashSet<org.joda.time.DateTime>(jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<org.joda.time.DateTime> borderValue5 = new java.util.HashSet<org.joda.time.DateTime>(java.util.Arrays.asList((org.joda.time.DateTime) null, org.joda.time.DateTime.now(), new org.joda.time.DateTime(0), new org.joda.time.DateTime(1, 1, 1, 0, 0, org.joda.time.DateTimeZone.UTC), new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L)));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<org.joda.time.DateTime> borderValue5JsonDeserialized = new java.util.HashSet<org.joda.time.DateTime>(jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Timestamp/NullableSetOfOneTimestampsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Timestamp/NullableSetOfOneTimestampsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Timestamp;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfOneTimestampsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<org.joda.time.DateTime> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<org.joda.time.DateTime> defaultValueJsonDeserialized = new java.util.HashSet<org.joda.time.DateTime>(jsonSerialization.deserializeList(org.joda.time.DateTime.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<org.joda.time.DateTime> borderValue1 = new java.util.HashSet<org.joda.time.DateTime>(java.util.Arrays.asList(org.joda.time.DateTime.now()));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<org.joda.time.DateTime> borderValue1JsonDeserialized = new java.util.HashSet<org.joda.time.DateTime>(jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<org.joda.time.DateTime> borderValue2 = new java.util.HashSet<org.joda.time.DateTime>(java.util.Arrays.asList(new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<org.joda.time.DateTime> borderValue2JsonDeserialized = new java.util.HashSet<org.joda.time.DateTime>(jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<org.joda.time.DateTime> borderValue3 = new java.util.HashSet<org.joda.time.DateTime>(java.util.Arrays.asList(org.joda.time.DateTime.now(), new org.joda.time.DateTime(0), new org.joda.time.DateTime(1, 1, 1, 0, 0, org.joda.time.DateTimeZone.UTC), new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<org.joda.time.DateTime> borderValue3JsonDeserialized = new java.util.HashSet<org.joda.time.DateTime>(jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Timestamp/NullableTimestampDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Timestamp/NullableTimestampDefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Timestamp;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableTimestampDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final org.joda.time.DateTime defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final org.joda.time.DateTime defaultValueJsonDeserialized = jsonSerialization.deserialize(org.joda.time.DateTime.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final org.joda.time.DateTime borderValue1 = org.joda.time.DateTime.now();
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final org.joda.time.DateTime borderValue1JsonDeserialized = jsonSerialization.deserialize(org.joda.time.DateTime.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final org.joda.time.DateTime borderValue2 = new org.joda.time.DateTime(0);
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final org.joda.time.DateTime borderValue2JsonDeserialized = jsonSerialization.deserialize(org.joda.time.DateTime.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final org.joda.time.DateTime borderValue3 = new org.joda.time.DateTime(1, 1, 1, 0, 0, org.joda.time.DateTimeZone.UTC);
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final org.joda.time.DateTime borderValue3JsonDeserialized = jsonSerialization.deserialize(org.joda.time.DateTime.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final org.joda.time.DateTime borderValue4 = new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L);
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final org.joda.time.DateTime borderValue4JsonDeserialized = jsonSerialization.deserialize(org.joda.time.DateTime.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Timestamp/OneArrayOfNullableTimestampsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Timestamp/OneArrayOfNullableTimestampsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Timestamp;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfNullableTimestampsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final org.joda.time.DateTime[] defaultValue = new org.joda.time.DateTime[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final org.joda.time.DateTime[] defaultValueJsonDeserialized = jsonSerialization.deserialize(org.joda.time.DateTime[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final org.joda.time.DateTime[] borderValue1 = new org.joda.time.DateTime[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final org.joda.time.DateTime[] borderValue1JsonDeserialized = jsonSerialization.deserialize(org.joda.time.DateTime[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final org.joda.time.DateTime[] borderValue2 = new org.joda.time.DateTime[] { org.joda.time.DateTime.now() };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final org.joda.time.DateTime[] borderValue2JsonDeserialized = jsonSerialization.deserialize(org.joda.time.DateTime[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final org.joda.time.DateTime[] borderValue3 = new org.joda.time.DateTime[] { new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L) };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final org.joda.time.DateTime[] borderValue3JsonDeserialized = jsonSerialization.deserialize(org.joda.time.DateTime[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final org.joda.time.DateTime[] borderValue4 = new org.joda.time.DateTime[] { org.joda.time.DateTime.now(), new org.joda.time.DateTime(0), new org.joda.time.DateTime(1, 1, 1, 0, 0, org.joda.time.DateTimeZone.UTC), new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L) };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final org.joda.time.DateTime[] borderValue4JsonDeserialized = jsonSerialization.deserialize(org.joda.time.DateTime[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final org.joda.time.DateTime[] borderValue5 = new org.joda.time.DateTime[] { null, org.joda.time.DateTime.now(), new org.joda.time.DateTime(0), new org.joda.time.DateTime(1, 1, 1, 0, 0, org.joda.time.DateTimeZone.UTC), new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L) };
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final org.joda.time.DateTime[] borderValue5JsonDeserialized = jsonSerialization.deserialize(org.joda.time.DateTime[].class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneArrayOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Timestamp/OneArrayOfOneTimestampsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Timestamp/OneArrayOfOneTimestampsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Timestamp;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfOneTimestampsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final org.joda.time.DateTime[] defaultValue = new org.joda.time.DateTime[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final org.joda.time.DateTime[] defaultValueJsonDeserialized = jsonSerialization.deserialize(org.joda.time.DateTime[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final org.joda.time.DateTime[] borderValue1 = new org.joda.time.DateTime[] { org.joda.time.DateTime.now() };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final org.joda.time.DateTime[] borderValue1JsonDeserialized = jsonSerialization.deserialize(org.joda.time.DateTime[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final org.joda.time.DateTime[] borderValue2 = new org.joda.time.DateTime[] { new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L) };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final org.joda.time.DateTime[] borderValue2JsonDeserialized = jsonSerialization.deserialize(org.joda.time.DateTime[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final org.joda.time.DateTime[] borderValue3 = new org.joda.time.DateTime[] { org.joda.time.DateTime.now(), new org.joda.time.DateTime(0), new org.joda.time.DateTime(1, 1, 1, 0, 0, org.joda.time.DateTimeZone.UTC), new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L) };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final org.joda.time.DateTime[] borderValue3JsonDeserialized = jsonSerialization.deserialize(org.joda.time.DateTime[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneArrayOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Timestamp/OneListOfNullableTimestampsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Timestamp/OneListOfNullableTimestampsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Timestamp;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfNullableTimestampsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<org.joda.time.DateTime> defaultValue = new java.util.ArrayList<org.joda.time.DateTime>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<org.joda.time.DateTime> defaultValueJsonDeserialized = jsonSerialization.deserializeList(org.joda.time.DateTime.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<org.joda.time.DateTime> borderValue1 = new java.util.ArrayList<org.joda.time.DateTime>(java.util.Arrays.asList((org.joda.time.DateTime) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<org.joda.time.DateTime> borderValue1JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<org.joda.time.DateTime> borderValue2 = new java.util.ArrayList<org.joda.time.DateTime>(java.util.Arrays.asList(org.joda.time.DateTime.now()));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<org.joda.time.DateTime> borderValue2JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<org.joda.time.DateTime> borderValue3 = new java.util.ArrayList<org.joda.time.DateTime>(java.util.Arrays.asList(new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<org.joda.time.DateTime> borderValue3JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<org.joda.time.DateTime> borderValue4 = new java.util.ArrayList<org.joda.time.DateTime>(java.util.Arrays.asList(org.joda.time.DateTime.now(), new org.joda.time.DateTime(0), new org.joda.time.DateTime(1, 1, 1, 0, 0, org.joda.time.DateTimeZone.UTC), new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L)));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<org.joda.time.DateTime> borderValue4JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.List<org.joda.time.DateTime> borderValue5 = new java.util.ArrayList<org.joda.time.DateTime>(java.util.Arrays.asList((org.joda.time.DateTime) null, org.joda.time.DateTime.now(), new org.joda.time.DateTime(0), new org.joda.time.DateTime(1, 1, 1, 0, 0, org.joda.time.DateTimeZone.UTC), new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L)));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.List<org.joda.time.DateTime> borderValue5JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneListOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Timestamp/OneListOfOneTimestampsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Timestamp/OneListOfOneTimestampsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Timestamp;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfOneTimestampsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<org.joda.time.DateTime> defaultValue = new java.util.ArrayList<org.joda.time.DateTime>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<org.joda.time.DateTime> defaultValueJsonDeserialized = jsonSerialization.deserializeList(org.joda.time.DateTime.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<org.joda.time.DateTime> borderValue1 = new java.util.ArrayList<org.joda.time.DateTime>(java.util.Arrays.asList(org.joda.time.DateTime.now()));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<org.joda.time.DateTime> borderValue1JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<org.joda.time.DateTime> borderValue2 = new java.util.ArrayList<org.joda.time.DateTime>(java.util.Arrays.asList(new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<org.joda.time.DateTime> borderValue2JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<org.joda.time.DateTime> borderValue3 = new java.util.ArrayList<org.joda.time.DateTime>(java.util.Arrays.asList(org.joda.time.DateTime.now(), new org.joda.time.DateTime(0), new org.joda.time.DateTime(1, 1, 1, 0, 0, org.joda.time.DateTimeZone.UTC), new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<org.joda.time.DateTime> borderValue3JsonDeserialized = jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneListOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Timestamp/OneSetOfNullableTimestampsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Timestamp/OneSetOfNullableTimestampsDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Timestamp;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfNullableTimestampsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<org.joda.time.DateTime> defaultValue = new java.util.HashSet<org.joda.time.DateTime>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<org.joda.time.DateTime> defaultValueJsonDeserialized = new java.util.HashSet<org.joda.time.DateTime>(jsonSerialization.deserializeList(org.joda.time.DateTime.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<org.joda.time.DateTime> borderValue1 = new java.util.HashSet<org.joda.time.DateTime>(java.util.Arrays.asList((org.joda.time.DateTime) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<org.joda.time.DateTime> borderValue1JsonDeserialized = new java.util.HashSet<org.joda.time.DateTime>(jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<org.joda.time.DateTime> borderValue2 = new java.util.HashSet<org.joda.time.DateTime>(java.util.Arrays.asList(org.joda.time.DateTime.now()));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<org.joda.time.DateTime> borderValue2JsonDeserialized = new java.util.HashSet<org.joda.time.DateTime>(jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<org.joda.time.DateTime> borderValue3 = new java.util.HashSet<org.joda.time.DateTime>(java.util.Arrays.asList(new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<org.joda.time.DateTime> borderValue3JsonDeserialized = new java.util.HashSet<org.joda.time.DateTime>(jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<org.joda.time.DateTime> borderValue4 = new java.util.HashSet<org.joda.time.DateTime>(java.util.Arrays.asList(org.joda.time.DateTime.now(), new org.joda.time.DateTime(0), new org.joda.time.DateTime(1, 1, 1, 0, 0, org.joda.time.DateTimeZone.UTC), new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L)));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<org.joda.time.DateTime> borderValue4JsonDeserialized = new java.util.HashSet<org.joda.time.DateTime>(jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.util.Set<org.joda.time.DateTime> borderValue5 = new java.util.HashSet<org.joda.time.DateTime>(java.util.Arrays.asList((org.joda.time.DateTime) null, org.joda.time.DateTime.now(), new org.joda.time.DateTime(0), new org.joda.time.DateTime(1, 1, 1, 0, 0, org.joda.time.DateTimeZone.UTC), new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L)));
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.util.Set<org.joda.time.DateTime> borderValue5JsonDeserialized = new java.util.HashSet<org.joda.time.DateTime>(jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneSetOfNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Timestamp/OneSetOfOneTimestampsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Timestamp/OneSetOfOneTimestampsDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Timestamp;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfOneTimestampsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<org.joda.time.DateTime> defaultValue = new java.util.HashSet<org.joda.time.DateTime>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<org.joda.time.DateTime> defaultValueJsonDeserialized = new java.util.HashSet<org.joda.time.DateTime>(jsonSerialization.deserializeList(org.joda.time.DateTime.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<org.joda.time.DateTime> borderValue1 = new java.util.HashSet<org.joda.time.DateTime>(java.util.Arrays.asList(org.joda.time.DateTime.now()));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<org.joda.time.DateTime> borderValue1JsonDeserialized = new java.util.HashSet<org.joda.time.DateTime>(jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<org.joda.time.DateTime> borderValue2 = new java.util.HashSet<org.joda.time.DateTime>(java.util.Arrays.asList(new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L)));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<org.joda.time.DateTime> borderValue2JsonDeserialized = new java.util.HashSet<org.joda.time.DateTime>(jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<org.joda.time.DateTime> borderValue3 = new java.util.HashSet<org.joda.time.DateTime>(java.util.Arrays.asList(org.joda.time.DateTime.now(), new org.joda.time.DateTime(0), new org.joda.time.DateTime(1, 1, 1, 0, 0, org.joda.time.DateTimeZone.UTC), new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L)));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<org.joda.time.DateTime> borderValue3JsonDeserialized = new java.util.HashSet<org.joda.time.DateTime>(jsonSerialization.deserializeList(org.joda.time.DateTime.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneSetOfOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Timestamp/OneTimestampDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Timestamp/OneTimestampDefaultValueTurtle.java
@@ -1,0 +1,55 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Timestamp;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneTimestampDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final org.joda.time.DateTime defaultValue = org.joda.time.DateTime.now();
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final org.joda.time.DateTime defaultValueJsonDeserialized = jsonSerialization.deserialize(org.joda.time.DateTime.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final org.joda.time.DateTime borderValue1 = new org.joda.time.DateTime(0);
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final org.joda.time.DateTime borderValue1JsonDeserialized = jsonSerialization.deserialize(org.joda.time.DateTime.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final org.joda.time.DateTime borderValue2 = new org.joda.time.DateTime(1, 1, 1, 0, 0, org.joda.time.DateTimeZone.UTC);
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final org.joda.time.DateTime borderValue2JsonDeserialized = jsonSerialization.deserialize(org.joda.time.DateTime.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final org.joda.time.DateTime borderValue3 = new org.joda.time.DateTime(Integer.MAX_VALUE * 1001L);
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final org.joda.time.DateTime borderValue3JsonDeserialized = jsonSerialization.deserialize(org.joda.time.DateTime.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.TimestampAsserts.assertOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Url/NullableArrayOfNullableUrlsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Url/NullableArrayOfNullableUrlsDefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Url;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfNullableUrlsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.net.URI[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.net.URI[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.net.URI[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.net.URI[] borderValue1 = new java.net.URI[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.net.URI[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.net.URI[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.net.URI[] borderValue2 = new java.net.URI[] { com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)") };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.net.URI[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.net.URI[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.net.URI[] borderValue3 = new java.net.URI[] { com.dslplatform.ocd.test.TypeFactory.buildURI("http://127.0.0.1/"), com.dslplatform.ocd.test.TypeFactory.buildURI("http://www.xyz.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://www.abc.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("ftp://www.pqr.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://localhost:8080/"), com.dslplatform.ocd.test.TypeFactory.buildURI("mailto:snail@mail.hu"), com.dslplatform.ocd.test.TypeFactory.buildURI("file:///~/opt/somefile.md"), com.dslplatform.ocd.test.TypeFactory.buildURI("tcp://localhost:8181/"), com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)") };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.net.URI[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.net.URI[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.net.URI[] borderValue4 = new java.net.URI[] { null, com.dslplatform.ocd.test.TypeFactory.buildURI("http://127.0.0.1/"), com.dslplatform.ocd.test.TypeFactory.buildURI("http://www.xyz.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://www.abc.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("ftp://www.pqr.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://localhost:8080/"), com.dslplatform.ocd.test.TypeFactory.buildURI("mailto:snail@mail.hu"), com.dslplatform.ocd.test.TypeFactory.buildURI("file:///~/opt/somefile.md"), com.dslplatform.ocd.test.TypeFactory.buildURI("tcp://localhost:8181/"), com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)") };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.net.URI[] borderValue4JsonDeserialized = jsonSerialization.deserialize(java.net.URI[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Url/NullableArrayOfOneUrlsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Url/NullableArrayOfOneUrlsDefaultValueTurtle.java
@@ -1,0 +1,46 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Url;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfOneUrlsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.net.URI[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.net.URI[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.net.URI[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.net.URI[] borderValue1 = new java.net.URI[] { com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)") };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.net.URI[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.net.URI[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.net.URI[] borderValue2 = new java.net.URI[] { com.dslplatform.ocd.test.TypeFactory.buildURI("http://127.0.0.1/"), com.dslplatform.ocd.test.TypeFactory.buildURI("http://www.xyz.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://www.abc.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("ftp://www.pqr.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://localhost:8080/"), com.dslplatform.ocd.test.TypeFactory.buildURI("mailto:snail@mail.hu"), com.dslplatform.ocd.test.TypeFactory.buildURI("file:///~/opt/somefile.md"), com.dslplatform.ocd.test.TypeFactory.buildURI("tcp://localhost:8181/"), com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)") };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.net.URI[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.net.URI[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Url/NullableListOfNullableUrlsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Url/NullableListOfNullableUrlsDefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Url;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfNullableUrlsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.net.URI> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.net.URI> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.net.URI.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.net.URI> borderValue1 = new java.util.ArrayList<java.net.URI>(java.util.Arrays.asList((java.net.URI) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.net.URI> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.net.URI.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.net.URI> borderValue2 = new java.util.ArrayList<java.net.URI>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.net.URI> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.net.URI.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.net.URI> borderValue3 = new java.util.ArrayList<java.net.URI>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildURI("http://127.0.0.1/"), com.dslplatform.ocd.test.TypeFactory.buildURI("http://www.xyz.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://www.abc.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("ftp://www.pqr.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://localhost:8080/"), com.dslplatform.ocd.test.TypeFactory.buildURI("mailto:snail@mail.hu"), com.dslplatform.ocd.test.TypeFactory.buildURI("file:///~/opt/somefile.md"), com.dslplatform.ocd.test.TypeFactory.buildURI("tcp://localhost:8181/"), com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.net.URI> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.net.URI.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<java.net.URI> borderValue4 = new java.util.ArrayList<java.net.URI>(java.util.Arrays.asList((java.net.URI) null, com.dslplatform.ocd.test.TypeFactory.buildURI("http://127.0.0.1/"), com.dslplatform.ocd.test.TypeFactory.buildURI("http://www.xyz.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://www.abc.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("ftp://www.pqr.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://localhost:8080/"), com.dslplatform.ocd.test.TypeFactory.buildURI("mailto:snail@mail.hu"), com.dslplatform.ocd.test.TypeFactory.buildURI("file:///~/opt/somefile.md"), com.dslplatform.ocd.test.TypeFactory.buildURI("tcp://localhost:8181/"), com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)")));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<java.net.URI> borderValue4JsonDeserialized = jsonSerialization.deserializeList(java.net.URI.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Url/NullableListOfOneUrlsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Url/NullableListOfOneUrlsDefaultValueTurtle.java
@@ -1,0 +1,46 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Url;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfOneUrlsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.net.URI> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.net.URI> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.net.URI.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.net.URI> borderValue1 = new java.util.ArrayList<java.net.URI>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)")));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.net.URI> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.net.URI.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.net.URI> borderValue2 = new java.util.ArrayList<java.net.URI>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildURI("http://127.0.0.1/"), com.dslplatform.ocd.test.TypeFactory.buildURI("http://www.xyz.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://www.abc.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("ftp://www.pqr.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://localhost:8080/"), com.dslplatform.ocd.test.TypeFactory.buildURI("mailto:snail@mail.hu"), com.dslplatform.ocd.test.TypeFactory.buildURI("file:///~/opt/somefile.md"), com.dslplatform.ocd.test.TypeFactory.buildURI("tcp://localhost:8181/"), com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.net.URI> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.net.URI.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Url/NullableSetOfNullableUrlsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Url/NullableSetOfNullableUrlsDefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Url;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfNullableUrlsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.net.URI> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.net.URI> defaultValueJsonDeserialized = new java.util.HashSet<java.net.URI>(jsonSerialization.deserializeList(java.net.URI.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.net.URI> borderValue1 = new java.util.HashSet<java.net.URI>(java.util.Arrays.asList((java.net.URI) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.net.URI> borderValue1JsonDeserialized = new java.util.HashSet<java.net.URI>(jsonSerialization.deserializeList(java.net.URI.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.net.URI> borderValue2 = new java.util.HashSet<java.net.URI>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.net.URI> borderValue2JsonDeserialized = new java.util.HashSet<java.net.URI>(jsonSerialization.deserializeList(java.net.URI.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.net.URI> borderValue3 = new java.util.HashSet<java.net.URI>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildURI("http://127.0.0.1/"), com.dslplatform.ocd.test.TypeFactory.buildURI("http://www.xyz.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://www.abc.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("ftp://www.pqr.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://localhost:8080/"), com.dslplatform.ocd.test.TypeFactory.buildURI("mailto:snail@mail.hu"), com.dslplatform.ocd.test.TypeFactory.buildURI("file:///~/opt/somefile.md"), com.dslplatform.ocd.test.TypeFactory.buildURI("tcp://localhost:8181/"), com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.net.URI> borderValue3JsonDeserialized = new java.util.HashSet<java.net.URI>(jsonSerialization.deserializeList(java.net.URI.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<java.net.URI> borderValue4 = new java.util.HashSet<java.net.URI>(java.util.Arrays.asList((java.net.URI) null, com.dslplatform.ocd.test.TypeFactory.buildURI("http://127.0.0.1/"), com.dslplatform.ocd.test.TypeFactory.buildURI("http://www.xyz.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://www.abc.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("ftp://www.pqr.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://localhost:8080/"), com.dslplatform.ocd.test.TypeFactory.buildURI("mailto:snail@mail.hu"), com.dslplatform.ocd.test.TypeFactory.buildURI("file:///~/opt/somefile.md"), com.dslplatform.ocd.test.TypeFactory.buildURI("tcp://localhost:8181/"), com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)")));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<java.net.URI> borderValue4JsonDeserialized = new java.util.HashSet<java.net.URI>(jsonSerialization.deserializeList(java.net.URI.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Url/NullableSetOfOneUrlsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Url/NullableSetOfOneUrlsDefaultValueTurtle.java
@@ -1,0 +1,46 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Url;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfOneUrlsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.net.URI> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.net.URI> defaultValueJsonDeserialized = new java.util.HashSet<java.net.URI>(jsonSerialization.deserializeList(java.net.URI.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.net.URI> borderValue1 = new java.util.HashSet<java.net.URI>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)")));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.net.URI> borderValue1JsonDeserialized = new java.util.HashSet<java.net.URI>(jsonSerialization.deserializeList(java.net.URI.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.net.URI> borderValue2 = new java.util.HashSet<java.net.URI>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildURI("http://127.0.0.1/"), com.dslplatform.ocd.test.TypeFactory.buildURI("http://www.xyz.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://www.abc.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("ftp://www.pqr.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://localhost:8080/"), com.dslplatform.ocd.test.TypeFactory.buildURI("mailto:snail@mail.hu"), com.dslplatform.ocd.test.TypeFactory.buildURI("file:///~/opt/somefile.md"), com.dslplatform.ocd.test.TypeFactory.buildURI("tcp://localhost:8181/"), com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.net.URI> borderValue2JsonDeserialized = new java.util.HashSet<java.net.URI>(jsonSerialization.deserializeList(java.net.URI.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Url/NullableUrlDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Url/NullableUrlDefaultValueTurtle.java
@@ -1,0 +1,109 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Url;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableUrlDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.net.URI defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.net.URI defaultValueJsonDeserialized = jsonSerialization.deserialize(java.net.URI.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.net.URI borderValue1 = com.dslplatform.ocd.test.TypeFactory.buildURI("http://127.0.0.1/");
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.net.URI borderValue1JsonDeserialized = jsonSerialization.deserialize(java.net.URI.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.net.URI borderValue2 = com.dslplatform.ocd.test.TypeFactory.buildURI("http://www.xyz.com/");
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.net.URI borderValue2JsonDeserialized = jsonSerialization.deserialize(java.net.URI.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.net.URI borderValue3 = com.dslplatform.ocd.test.TypeFactory.buildURI("https://www.abc.com/");
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.net.URI borderValue3JsonDeserialized = jsonSerialization.deserialize(java.net.URI.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.net.URI borderValue4 = com.dslplatform.ocd.test.TypeFactory.buildURI("ftp://www.pqr.com/");
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.net.URI borderValue4JsonDeserialized = jsonSerialization.deserialize(java.net.URI.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.net.URI borderValue5 = com.dslplatform.ocd.test.TypeFactory.buildURI("https://localhost:8080/");
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.net.URI borderValue5JsonDeserialized = jsonSerialization.deserialize(java.net.URI.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue6Equality() throws IOException {
+        final java.net.URI borderValue6 = com.dslplatform.ocd.test.TypeFactory.buildURI("mailto:snail@mail.hu");
+        final Bytes borderValue6JsonSerialized = jsonSerialization.serialize(borderValue6);
+        final java.net.URI borderValue6JsonDeserialized = jsonSerialization.deserialize(java.net.URI.class, borderValue6JsonSerialized.content, borderValue6JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableEquals(borderValue6, borderValue6JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue7Equality() throws IOException {
+        final java.net.URI borderValue7 = com.dslplatform.ocd.test.TypeFactory.buildURI("file:///~/opt/somefile.md");
+        final Bytes borderValue7JsonSerialized = jsonSerialization.serialize(borderValue7);
+        final java.net.URI borderValue7JsonDeserialized = jsonSerialization.deserialize(java.net.URI.class, borderValue7JsonSerialized.content, borderValue7JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableEquals(borderValue7, borderValue7JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue8Equality() throws IOException {
+        final java.net.URI borderValue8 = com.dslplatform.ocd.test.TypeFactory.buildURI("tcp://localhost:8181/");
+        final Bytes borderValue8JsonSerialized = jsonSerialization.serialize(borderValue8);
+        final java.net.URI borderValue8JsonDeserialized = jsonSerialization.deserialize(java.net.URI.class, borderValue8JsonSerialized.content, borderValue8JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableEquals(borderValue8, borderValue8JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue9Equality() throws IOException {
+        final java.net.URI borderValue9 = com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)");
+        final Bytes borderValue9JsonSerialized = jsonSerialization.serialize(borderValue9);
+        final java.net.URI borderValue9JsonDeserialized = jsonSerialization.deserialize(java.net.URI.class, borderValue9JsonSerialized.content, borderValue9JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertNullableEquals(borderValue9, borderValue9JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Url/OneArrayOfNullableUrlsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Url/OneArrayOfNullableUrlsDefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Url;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfNullableUrlsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.net.URI[] defaultValue = new java.net.URI[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.net.URI[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.net.URI[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.net.URI[] borderValue1 = new java.net.URI[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.net.URI[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.net.URI[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.net.URI[] borderValue2 = new java.net.URI[] { com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)") };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.net.URI[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.net.URI[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.net.URI[] borderValue3 = new java.net.URI[] { com.dslplatform.ocd.test.TypeFactory.buildURI("http://127.0.0.1/"), com.dslplatform.ocd.test.TypeFactory.buildURI("http://www.xyz.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://www.abc.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("ftp://www.pqr.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://localhost:8080/"), com.dslplatform.ocd.test.TypeFactory.buildURI("mailto:snail@mail.hu"), com.dslplatform.ocd.test.TypeFactory.buildURI("file:///~/opt/somefile.md"), com.dslplatform.ocd.test.TypeFactory.buildURI("tcp://localhost:8181/"), com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)") };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.net.URI[] borderValue3JsonDeserialized = jsonSerialization.deserialize(java.net.URI[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.net.URI[] borderValue4 = new java.net.URI[] { null, com.dslplatform.ocd.test.TypeFactory.buildURI("http://127.0.0.1/"), com.dslplatform.ocd.test.TypeFactory.buildURI("http://www.xyz.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://www.abc.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("ftp://www.pqr.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://localhost:8080/"), com.dslplatform.ocd.test.TypeFactory.buildURI("mailto:snail@mail.hu"), com.dslplatform.ocd.test.TypeFactory.buildURI("file:///~/opt/somefile.md"), com.dslplatform.ocd.test.TypeFactory.buildURI("tcp://localhost:8181/"), com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)") };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.net.URI[] borderValue4JsonDeserialized = jsonSerialization.deserialize(java.net.URI[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Url/OneArrayOfOneUrlsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Url/OneArrayOfOneUrlsDefaultValueTurtle.java
@@ -1,0 +1,46 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Url;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfOneUrlsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.net.URI[] defaultValue = new java.net.URI[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.net.URI[] defaultValueJsonDeserialized = jsonSerialization.deserialize(java.net.URI[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.net.URI[] borderValue1 = new java.net.URI[] { com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)") };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.net.URI[] borderValue1JsonDeserialized = jsonSerialization.deserialize(java.net.URI[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.net.URI[] borderValue2 = new java.net.URI[] { com.dslplatform.ocd.test.TypeFactory.buildURI("http://127.0.0.1/"), com.dslplatform.ocd.test.TypeFactory.buildURI("http://www.xyz.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://www.abc.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("ftp://www.pqr.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://localhost:8080/"), com.dslplatform.ocd.test.TypeFactory.buildURI("mailto:snail@mail.hu"), com.dslplatform.ocd.test.TypeFactory.buildURI("file:///~/opt/somefile.md"), com.dslplatform.ocd.test.TypeFactory.buildURI("tcp://localhost:8181/"), com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)") };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.net.URI[] borderValue2JsonDeserialized = jsonSerialization.deserialize(java.net.URI[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Url/OneListOfNullableUrlsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Url/OneListOfNullableUrlsDefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Url;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfNullableUrlsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.net.URI> defaultValue = new java.util.ArrayList<java.net.URI>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.net.URI> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.net.URI.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.net.URI> borderValue1 = new java.util.ArrayList<java.net.URI>(java.util.Arrays.asList((java.net.URI) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.net.URI> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.net.URI.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.net.URI> borderValue2 = new java.util.ArrayList<java.net.URI>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.net.URI> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.net.URI.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<java.net.URI> borderValue3 = new java.util.ArrayList<java.net.URI>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildURI("http://127.0.0.1/"), com.dslplatform.ocd.test.TypeFactory.buildURI("http://www.xyz.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://www.abc.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("ftp://www.pqr.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://localhost:8080/"), com.dslplatform.ocd.test.TypeFactory.buildURI("mailto:snail@mail.hu"), com.dslplatform.ocd.test.TypeFactory.buildURI("file:///~/opt/somefile.md"), com.dslplatform.ocd.test.TypeFactory.buildURI("tcp://localhost:8181/"), com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<java.net.URI> borderValue3JsonDeserialized = jsonSerialization.deserializeList(java.net.URI.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<java.net.URI> borderValue4 = new java.util.ArrayList<java.net.URI>(java.util.Arrays.asList((java.net.URI) null, com.dslplatform.ocd.test.TypeFactory.buildURI("http://127.0.0.1/"), com.dslplatform.ocd.test.TypeFactory.buildURI("http://www.xyz.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://www.abc.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("ftp://www.pqr.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://localhost:8080/"), com.dslplatform.ocd.test.TypeFactory.buildURI("mailto:snail@mail.hu"), com.dslplatform.ocd.test.TypeFactory.buildURI("file:///~/opt/somefile.md"), com.dslplatform.ocd.test.TypeFactory.buildURI("tcp://localhost:8181/"), com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)")));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<java.net.URI> borderValue4JsonDeserialized = jsonSerialization.deserializeList(java.net.URI.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Url/OneListOfOneUrlsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Url/OneListOfOneUrlsDefaultValueTurtle.java
@@ -1,0 +1,46 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Url;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfOneUrlsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<java.net.URI> defaultValue = new java.util.ArrayList<java.net.URI>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<java.net.URI> defaultValueJsonDeserialized = jsonSerialization.deserializeList(java.net.URI.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<java.net.URI> borderValue1 = new java.util.ArrayList<java.net.URI>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)")));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<java.net.URI> borderValue1JsonDeserialized = jsonSerialization.deserializeList(java.net.URI.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<java.net.URI> borderValue2 = new java.util.ArrayList<java.net.URI>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildURI("http://127.0.0.1/"), com.dslplatform.ocd.test.TypeFactory.buildURI("http://www.xyz.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://www.abc.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("ftp://www.pqr.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://localhost:8080/"), com.dslplatform.ocd.test.TypeFactory.buildURI("mailto:snail@mail.hu"), com.dslplatform.ocd.test.TypeFactory.buildURI("file:///~/opt/somefile.md"), com.dslplatform.ocd.test.TypeFactory.buildURI("tcp://localhost:8181/"), com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<java.net.URI> borderValue2JsonDeserialized = jsonSerialization.deserializeList(java.net.URI.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Url/OneSetOfNullableUrlsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Url/OneSetOfNullableUrlsDefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Url;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfNullableUrlsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.net.URI> defaultValue = new java.util.HashSet<java.net.URI>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.net.URI> defaultValueJsonDeserialized = new java.util.HashSet<java.net.URI>(jsonSerialization.deserializeList(java.net.URI.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.net.URI> borderValue1 = new java.util.HashSet<java.net.URI>(java.util.Arrays.asList((java.net.URI) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.net.URI> borderValue1JsonDeserialized = new java.util.HashSet<java.net.URI>(jsonSerialization.deserializeList(java.net.URI.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.net.URI> borderValue2 = new java.util.HashSet<java.net.URI>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.net.URI> borderValue2JsonDeserialized = new java.util.HashSet<java.net.URI>(jsonSerialization.deserializeList(java.net.URI.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<java.net.URI> borderValue3 = new java.util.HashSet<java.net.URI>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildURI("http://127.0.0.1/"), com.dslplatform.ocd.test.TypeFactory.buildURI("http://www.xyz.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://www.abc.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("ftp://www.pqr.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://localhost:8080/"), com.dslplatform.ocd.test.TypeFactory.buildURI("mailto:snail@mail.hu"), com.dslplatform.ocd.test.TypeFactory.buildURI("file:///~/opt/somefile.md"), com.dslplatform.ocd.test.TypeFactory.buildURI("tcp://localhost:8181/"), com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<java.net.URI> borderValue3JsonDeserialized = new java.util.HashSet<java.net.URI>(jsonSerialization.deserializeList(java.net.URI.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<java.net.URI> borderValue4 = new java.util.HashSet<java.net.URI>(java.util.Arrays.asList((java.net.URI) null, com.dslplatform.ocd.test.TypeFactory.buildURI("http://127.0.0.1/"), com.dslplatform.ocd.test.TypeFactory.buildURI("http://www.xyz.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://www.abc.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("ftp://www.pqr.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://localhost:8080/"), com.dslplatform.ocd.test.TypeFactory.buildURI("mailto:snail@mail.hu"), com.dslplatform.ocd.test.TypeFactory.buildURI("file:///~/opt/somefile.md"), com.dslplatform.ocd.test.TypeFactory.buildURI("tcp://localhost:8181/"), com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)")));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<java.net.URI> borderValue4JsonDeserialized = new java.util.HashSet<java.net.URI>(jsonSerialization.deserializeList(java.net.URI.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Url/OneSetOfOneUrlsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Url/OneSetOfOneUrlsDefaultValueTurtle.java
@@ -1,0 +1,46 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Url;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfOneUrlsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<java.net.URI> defaultValue = new java.util.HashSet<java.net.URI>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<java.net.URI> defaultValueJsonDeserialized = new java.util.HashSet<java.net.URI>(jsonSerialization.deserializeList(java.net.URI.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<java.net.URI> borderValue1 = new java.util.HashSet<java.net.URI>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)")));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<java.net.URI> borderValue1JsonDeserialized = new java.util.HashSet<java.net.URI>(jsonSerialization.deserializeList(java.net.URI.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<java.net.URI> borderValue2 = new java.util.HashSet<java.net.URI>(java.util.Arrays.asList(com.dslplatform.ocd.test.TypeFactory.buildURI("http://127.0.0.1/"), com.dslplatform.ocd.test.TypeFactory.buildURI("http://www.xyz.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://www.abc.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("ftp://www.pqr.com/"), com.dslplatform.ocd.test.TypeFactory.buildURI("https://localhost:8080/"), com.dslplatform.ocd.test.TypeFactory.buildURI("mailto:snail@mail.hu"), com.dslplatform.ocd.test.TypeFactory.buildURI("file:///~/opt/somefile.md"), com.dslplatform.ocd.test.TypeFactory.buildURI("tcp://localhost:8181/"), com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<java.net.URI> borderValue2JsonDeserialized = new java.util.HashSet<java.net.URI>(jsonSerialization.deserializeList(java.net.URI.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Url/OneUrlDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Url/OneUrlDefaultValueTurtle.java
@@ -1,0 +1,100 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Url;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneUrlDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.net.URI defaultValue = com.dslplatform.ocd.test.TypeFactory.buildURI("http://127.0.0.1/");
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.net.URI defaultValueJsonDeserialized = jsonSerialization.deserialize(java.net.URI.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.net.URI borderValue1 = com.dslplatform.ocd.test.TypeFactory.buildURI("http://www.xyz.com/");
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.net.URI borderValue1JsonDeserialized = jsonSerialization.deserialize(java.net.URI.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.net.URI borderValue2 = com.dslplatform.ocd.test.TypeFactory.buildURI("https://www.abc.com/");
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.net.URI borderValue2JsonDeserialized = jsonSerialization.deserialize(java.net.URI.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.net.URI borderValue3 = com.dslplatform.ocd.test.TypeFactory.buildURI("ftp://www.pqr.com/");
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.net.URI borderValue3JsonDeserialized = jsonSerialization.deserialize(java.net.URI.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.net.URI borderValue4 = com.dslplatform.ocd.test.TypeFactory.buildURI("https://localhost:8080/");
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.net.URI borderValue4JsonDeserialized = jsonSerialization.deserialize(java.net.URI.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final java.net.URI borderValue5 = com.dslplatform.ocd.test.TypeFactory.buildURI("mailto:snail@mail.hu");
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final java.net.URI borderValue5JsonDeserialized = jsonSerialization.deserialize(java.net.URI.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue6Equality() throws IOException {
+        final java.net.URI borderValue6 = com.dslplatform.ocd.test.TypeFactory.buildURI("file:///~/opt/somefile.md");
+        final Bytes borderValue6JsonSerialized = jsonSerialization.serialize(borderValue6);
+        final java.net.URI borderValue6JsonDeserialized = jsonSerialization.deserialize(java.net.URI.class, borderValue6JsonSerialized.content, borderValue6JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneEquals(borderValue6, borderValue6JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue7Equality() throws IOException {
+        final java.net.URI borderValue7 = com.dslplatform.ocd.test.TypeFactory.buildURI("tcp://localhost:8181/");
+        final Bytes borderValue7JsonSerialized = jsonSerialization.serialize(borderValue7);
+        final java.net.URI borderValue7JsonDeserialized = jsonSerialization.deserialize(java.net.URI.class, borderValue7JsonSerialized.content, borderValue7JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneEquals(borderValue7, borderValue7JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue8Equality() throws IOException {
+        final java.net.URI borderValue8 = com.dslplatform.ocd.test.TypeFactory.buildURI("failover:(tcp://localhost:8181,tcp://localhost:8080/)");
+        final Bytes borderValue8JsonSerialized = jsonSerialization.serialize(borderValue8);
+        final java.net.URI borderValue8JsonDeserialized = jsonSerialization.deserialize(java.net.URI.class, borderValue8JsonSerialized.content, borderValue8JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.UrlAsserts.assertOneEquals(borderValue8, borderValue8JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Xml/NullableArrayOfNullableXmlsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Xml/NullableArrayOfNullableXmlsDefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Xml;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfNullableXmlsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final org.w3c.dom.Element[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final org.w3c.dom.Element[] defaultValueJsonDeserialized = jsonSerialization.deserialize(org.w3c.dom.Element[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final org.w3c.dom.Element[] borderValue1 = new org.w3c.dom.Element[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final org.w3c.dom.Element[] borderValue1JsonDeserialized = jsonSerialization.deserialize(org.w3c.dom.Element[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final org.w3c.dom.Element[] borderValue2 = new org.w3c.dom.Element[] { com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>") };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final org.w3c.dom.Element[] borderValue2JsonDeserialized = jsonSerialization.deserialize(org.w3c.dom.Element[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final org.w3c.dom.Element[] borderValue3 = new org.w3c.dom.Element[] { com.dslplatform.ocd.test.Utils.stringToElement("<document/>"), com.dslplatform.ocd.test.Utils.stringToElement("<TextElement>some text &amp; &lt;stuff&gt;</TextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ElementWithCData>&lt;?xml?&gt;&lt;xml&gt;&lt;!xml!&gt;</ElementWithCData>"), com.dslplatform.ocd.test.Utils.stringToElement("<AtributedElement foo=\"bar\" qwe=\"poi\"/>"), com.dslplatform.ocd.test.Utils.stringToElement("<NestedTextElement><FirstNest><SecondNest>bird</SecondNest></FirstNest></NestedTextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>") };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final org.w3c.dom.Element[] borderValue3JsonDeserialized = jsonSerialization.deserialize(org.w3c.dom.Element[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final org.w3c.dom.Element[] borderValue4 = new org.w3c.dom.Element[] { null, com.dslplatform.ocd.test.Utils.stringToElement("<document/>"), com.dslplatform.ocd.test.Utils.stringToElement("<TextElement>some text &amp; &lt;stuff&gt;</TextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ElementWithCData>&lt;?xml?&gt;&lt;xml&gt;&lt;!xml!&gt;</ElementWithCData>"), com.dslplatform.ocd.test.Utils.stringToElement("<AtributedElement foo=\"bar\" qwe=\"poi\"/>"), com.dslplatform.ocd.test.Utils.stringToElement("<NestedTextElement><FirstNest><SecondNest>bird</SecondNest></FirstNest></NestedTextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>") };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final org.w3c.dom.Element[] borderValue4JsonDeserialized = jsonSerialization.deserialize(org.w3c.dom.Element[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Xml/NullableArrayOfOneXmlsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Xml/NullableArrayOfOneXmlsDefaultValueTurtle.java
@@ -1,0 +1,46 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Xml;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableArrayOfOneXmlsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final org.w3c.dom.Element[] defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final org.w3c.dom.Element[] defaultValueJsonDeserialized = jsonSerialization.deserialize(org.w3c.dom.Element[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final org.w3c.dom.Element[] borderValue1 = new org.w3c.dom.Element[] { com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>") };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final org.w3c.dom.Element[] borderValue1JsonDeserialized = jsonSerialization.deserialize(org.w3c.dom.Element[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final org.w3c.dom.Element[] borderValue2 = new org.w3c.dom.Element[] { com.dslplatform.ocd.test.Utils.stringToElement("<document/>"), com.dslplatform.ocd.test.Utils.stringToElement("<TextElement>some text &amp; &lt;stuff&gt;</TextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ElementWithCData>&lt;?xml?&gt;&lt;xml&gt;&lt;!xml!&gt;</ElementWithCData>"), com.dslplatform.ocd.test.Utils.stringToElement("<AtributedElement foo=\"bar\" qwe=\"poi\"/>"), com.dslplatform.ocd.test.Utils.stringToElement("<NestedTextElement><FirstNest><SecondNest>bird</SecondNest></FirstNest></NestedTextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>") };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final org.w3c.dom.Element[] borderValue2JsonDeserialized = jsonSerialization.deserialize(org.w3c.dom.Element[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Xml/NullableListOfNullableXmlsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Xml/NullableListOfNullableXmlsDefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Xml;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfNullableXmlsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<org.w3c.dom.Element> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<org.w3c.dom.Element> defaultValueJsonDeserialized = jsonSerialization.deserializeList(org.w3c.dom.Element.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<org.w3c.dom.Element> borderValue1 = new java.util.ArrayList<org.w3c.dom.Element>(java.util.Arrays.asList((org.w3c.dom.Element) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<org.w3c.dom.Element> borderValue1JsonDeserialized = jsonSerialization.deserializeList(org.w3c.dom.Element.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<org.w3c.dom.Element> borderValue2 = new java.util.ArrayList<org.w3c.dom.Element>(java.util.Arrays.asList(com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<org.w3c.dom.Element> borderValue2JsonDeserialized = jsonSerialization.deserializeList(org.w3c.dom.Element.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<org.w3c.dom.Element> borderValue3 = new java.util.ArrayList<org.w3c.dom.Element>(java.util.Arrays.asList(com.dslplatform.ocd.test.Utils.stringToElement("<document/>"), com.dslplatform.ocd.test.Utils.stringToElement("<TextElement>some text &amp; &lt;stuff&gt;</TextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ElementWithCData>&lt;?xml?&gt;&lt;xml&gt;&lt;!xml!&gt;</ElementWithCData>"), com.dslplatform.ocd.test.Utils.stringToElement("<AtributedElement foo=\"bar\" qwe=\"poi\"/>"), com.dslplatform.ocd.test.Utils.stringToElement("<NestedTextElement><FirstNest><SecondNest>bird</SecondNest></FirstNest></NestedTextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<org.w3c.dom.Element> borderValue3JsonDeserialized = jsonSerialization.deserializeList(org.w3c.dom.Element.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<org.w3c.dom.Element> borderValue4 = new java.util.ArrayList<org.w3c.dom.Element>(java.util.Arrays.asList((org.w3c.dom.Element) null, com.dslplatform.ocd.test.Utils.stringToElement("<document/>"), com.dslplatform.ocd.test.Utils.stringToElement("<TextElement>some text &amp; &lt;stuff&gt;</TextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ElementWithCData>&lt;?xml?&gt;&lt;xml&gt;&lt;!xml!&gt;</ElementWithCData>"), com.dslplatform.ocd.test.Utils.stringToElement("<AtributedElement foo=\"bar\" qwe=\"poi\"/>"), com.dslplatform.ocd.test.Utils.stringToElement("<NestedTextElement><FirstNest><SecondNest>bird</SecondNest></FirstNest></NestedTextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>")));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<org.w3c.dom.Element> borderValue4JsonDeserialized = jsonSerialization.deserializeList(org.w3c.dom.Element.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Xml/NullableListOfOneXmlsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Xml/NullableListOfOneXmlsDefaultValueTurtle.java
@@ -1,0 +1,46 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Xml;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableListOfOneXmlsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<org.w3c.dom.Element> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<org.w3c.dom.Element> defaultValueJsonDeserialized = jsonSerialization.deserializeList(org.w3c.dom.Element.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<org.w3c.dom.Element> borderValue1 = new java.util.ArrayList<org.w3c.dom.Element>(java.util.Arrays.asList(com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>")));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<org.w3c.dom.Element> borderValue1JsonDeserialized = jsonSerialization.deserializeList(org.w3c.dom.Element.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<org.w3c.dom.Element> borderValue2 = new java.util.ArrayList<org.w3c.dom.Element>(java.util.Arrays.asList(com.dslplatform.ocd.test.Utils.stringToElement("<document/>"), com.dslplatform.ocd.test.Utils.stringToElement("<TextElement>some text &amp; &lt;stuff&gt;</TextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ElementWithCData>&lt;?xml?&gt;&lt;xml&gt;&lt;!xml!&gt;</ElementWithCData>"), com.dslplatform.ocd.test.Utils.stringToElement("<AtributedElement foo=\"bar\" qwe=\"poi\"/>"), com.dslplatform.ocd.test.Utils.stringToElement("<NestedTextElement><FirstNest><SecondNest>bird</SecondNest></FirstNest></NestedTextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<org.w3c.dom.Element> borderValue2JsonDeserialized = jsonSerialization.deserializeList(org.w3c.dom.Element.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Xml/NullableSetOfNullableXmlsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Xml/NullableSetOfNullableXmlsDefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Xml;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfNullableXmlsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<org.w3c.dom.Element> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<org.w3c.dom.Element> defaultValueJsonDeserialized = new java.util.HashSet<org.w3c.dom.Element>(jsonSerialization.deserializeList(org.w3c.dom.Element.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<org.w3c.dom.Element> borderValue1 = new java.util.HashSet<org.w3c.dom.Element>(java.util.Arrays.asList((org.w3c.dom.Element) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<org.w3c.dom.Element> borderValue1JsonDeserialized = new java.util.HashSet<org.w3c.dom.Element>(jsonSerialization.deserializeList(org.w3c.dom.Element.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<org.w3c.dom.Element> borderValue2 = new java.util.HashSet<org.w3c.dom.Element>(java.util.Arrays.asList(com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<org.w3c.dom.Element> borderValue2JsonDeserialized = new java.util.HashSet<org.w3c.dom.Element>(jsonSerialization.deserializeList(org.w3c.dom.Element.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<org.w3c.dom.Element> borderValue3 = new java.util.HashSet<org.w3c.dom.Element>(java.util.Arrays.asList(com.dslplatform.ocd.test.Utils.stringToElement("<document/>"), com.dslplatform.ocd.test.Utils.stringToElement("<TextElement>some text &amp; &lt;stuff&gt;</TextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ElementWithCData>&lt;?xml?&gt;&lt;xml&gt;&lt;!xml!&gt;</ElementWithCData>"), com.dslplatform.ocd.test.Utils.stringToElement("<AtributedElement foo=\"bar\" qwe=\"poi\"/>"), com.dslplatform.ocd.test.Utils.stringToElement("<NestedTextElement><FirstNest><SecondNest>bird</SecondNest></FirstNest></NestedTextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<org.w3c.dom.Element> borderValue3JsonDeserialized = new java.util.HashSet<org.w3c.dom.Element>(jsonSerialization.deserializeList(org.w3c.dom.Element.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<org.w3c.dom.Element> borderValue4 = new java.util.HashSet<org.w3c.dom.Element>(java.util.Arrays.asList((org.w3c.dom.Element) null, com.dslplatform.ocd.test.Utils.stringToElement("<document/>"), com.dslplatform.ocd.test.Utils.stringToElement("<TextElement>some text &amp; &lt;stuff&gt;</TextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ElementWithCData>&lt;?xml?&gt;&lt;xml&gt;&lt;!xml!&gt;</ElementWithCData>"), com.dslplatform.ocd.test.Utils.stringToElement("<AtributedElement foo=\"bar\" qwe=\"poi\"/>"), com.dslplatform.ocd.test.Utils.stringToElement("<NestedTextElement><FirstNest><SecondNest>bird</SecondNest></FirstNest></NestedTextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>")));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<org.w3c.dom.Element> borderValue4JsonDeserialized = new java.util.HashSet<org.w3c.dom.Element>(jsonSerialization.deserializeList(org.w3c.dom.Element.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Xml/NullableSetOfOneXmlsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Xml/NullableSetOfOneXmlsDefaultValueTurtle.java
@@ -1,0 +1,46 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Xml;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableSetOfOneXmlsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<org.w3c.dom.Element> defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<org.w3c.dom.Element> defaultValueJsonDeserialized = new java.util.HashSet<org.w3c.dom.Element>(jsonSerialization.deserializeList(org.w3c.dom.Element.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<org.w3c.dom.Element> borderValue1 = new java.util.HashSet<org.w3c.dom.Element>(java.util.Arrays.asList(com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>")));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<org.w3c.dom.Element> borderValue1JsonDeserialized = new java.util.HashSet<org.w3c.dom.Element>(jsonSerialization.deserializeList(org.w3c.dom.Element.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<org.w3c.dom.Element> borderValue2 = new java.util.HashSet<org.w3c.dom.Element>(java.util.Arrays.asList(com.dslplatform.ocd.test.Utils.stringToElement("<document/>"), com.dslplatform.ocd.test.Utils.stringToElement("<TextElement>some text &amp; &lt;stuff&gt;</TextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ElementWithCData>&lt;?xml?&gt;&lt;xml&gt;&lt;!xml!&gt;</ElementWithCData>"), com.dslplatform.ocd.test.Utils.stringToElement("<AtributedElement foo=\"bar\" qwe=\"poi\"/>"), com.dslplatform.ocd.test.Utils.stringToElement("<NestedTextElement><FirstNest><SecondNest>bird</SecondNest></FirstNest></NestedTextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<org.w3c.dom.Element> borderValue2JsonDeserialized = new java.util.HashSet<org.w3c.dom.Element>(jsonSerialization.deserializeList(org.w3c.dom.Element.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Xml/NullableXmlDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Xml/NullableXmlDefaultValueTurtle.java
@@ -1,0 +1,82 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Xml;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class NullableXmlDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final org.w3c.dom.Element defaultValue = null;
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final org.w3c.dom.Element defaultValueJsonDeserialized = jsonSerialization.deserialize(org.w3c.dom.Element.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final org.w3c.dom.Element borderValue1 = com.dslplatform.ocd.test.Utils.stringToElement("<document/>");
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final org.w3c.dom.Element borderValue1JsonDeserialized = jsonSerialization.deserialize(org.w3c.dom.Element.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final org.w3c.dom.Element borderValue2 = com.dslplatform.ocd.test.Utils.stringToElement("<TextElement>some text &amp; &lt;stuff&gt;</TextElement>");
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final org.w3c.dom.Element borderValue2JsonDeserialized = jsonSerialization.deserialize(org.w3c.dom.Element.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final org.w3c.dom.Element borderValue3 = com.dslplatform.ocd.test.Utils.stringToElement("<ElementWithCData>&lt;?xml?&gt;&lt;xml&gt;&lt;!xml!&gt;</ElementWithCData>");
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final org.w3c.dom.Element borderValue3JsonDeserialized = jsonSerialization.deserialize(org.w3c.dom.Element.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final org.w3c.dom.Element borderValue4 = com.dslplatform.ocd.test.Utils.stringToElement("<AtributedElement foo=\"bar\" qwe=\"poi\"/>");
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final org.w3c.dom.Element borderValue4JsonDeserialized = jsonSerialization.deserialize(org.w3c.dom.Element.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final org.w3c.dom.Element borderValue5 = com.dslplatform.ocd.test.Utils.stringToElement("<NestedTextElement><FirstNest><SecondNest>bird</SecondNest></FirstNest></NestedTextElement>");
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final org.w3c.dom.Element borderValue5JsonDeserialized = jsonSerialization.deserialize(org.w3c.dom.Element.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue6Equality() throws IOException {
+        final org.w3c.dom.Element borderValue6 = com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>");
+        final Bytes borderValue6JsonSerialized = jsonSerialization.serialize(borderValue6);
+        final org.w3c.dom.Element borderValue6JsonDeserialized = jsonSerialization.deserialize(org.w3c.dom.Element.class, borderValue6JsonSerialized.content, borderValue6JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertNullableEquals(borderValue6, borderValue6JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Xml/OneArrayOfNullableXmlsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Xml/OneArrayOfNullableXmlsDefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Xml;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfNullableXmlsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final org.w3c.dom.Element[] defaultValue = new org.w3c.dom.Element[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final org.w3c.dom.Element[] defaultValueJsonDeserialized = jsonSerialization.deserialize(org.w3c.dom.Element[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneArrayOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final org.w3c.dom.Element[] borderValue1 = new org.w3c.dom.Element[] { null };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final org.w3c.dom.Element[] borderValue1JsonDeserialized = jsonSerialization.deserialize(org.w3c.dom.Element[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneArrayOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final org.w3c.dom.Element[] borderValue2 = new org.w3c.dom.Element[] { com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>") };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final org.w3c.dom.Element[] borderValue2JsonDeserialized = jsonSerialization.deserialize(org.w3c.dom.Element[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneArrayOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final org.w3c.dom.Element[] borderValue3 = new org.w3c.dom.Element[] { com.dslplatform.ocd.test.Utils.stringToElement("<document/>"), com.dslplatform.ocd.test.Utils.stringToElement("<TextElement>some text &amp; &lt;stuff&gt;</TextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ElementWithCData>&lt;?xml?&gt;&lt;xml&gt;&lt;!xml!&gt;</ElementWithCData>"), com.dslplatform.ocd.test.Utils.stringToElement("<AtributedElement foo=\"bar\" qwe=\"poi\"/>"), com.dslplatform.ocd.test.Utils.stringToElement("<NestedTextElement><FirstNest><SecondNest>bird</SecondNest></FirstNest></NestedTextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>") };
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final org.w3c.dom.Element[] borderValue3JsonDeserialized = jsonSerialization.deserialize(org.w3c.dom.Element[].class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneArrayOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final org.w3c.dom.Element[] borderValue4 = new org.w3c.dom.Element[] { null, com.dslplatform.ocd.test.Utils.stringToElement("<document/>"), com.dslplatform.ocd.test.Utils.stringToElement("<TextElement>some text &amp; &lt;stuff&gt;</TextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ElementWithCData>&lt;?xml?&gt;&lt;xml&gt;&lt;!xml!&gt;</ElementWithCData>"), com.dslplatform.ocd.test.Utils.stringToElement("<AtributedElement foo=\"bar\" qwe=\"poi\"/>"), com.dslplatform.ocd.test.Utils.stringToElement("<NestedTextElement><FirstNest><SecondNest>bird</SecondNest></FirstNest></NestedTextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>") };
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final org.w3c.dom.Element[] borderValue4JsonDeserialized = jsonSerialization.deserialize(org.w3c.dom.Element[].class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneArrayOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Xml/OneArrayOfOneXmlsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Xml/OneArrayOfOneXmlsDefaultValueTurtle.java
@@ -1,0 +1,46 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Xml;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneArrayOfOneXmlsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final org.w3c.dom.Element[] defaultValue = new org.w3c.dom.Element[0];
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final org.w3c.dom.Element[] defaultValueJsonDeserialized = jsonSerialization.deserialize(org.w3c.dom.Element[].class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneArrayOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final org.w3c.dom.Element[] borderValue1 = new org.w3c.dom.Element[] { com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>") };
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final org.w3c.dom.Element[] borderValue1JsonDeserialized = jsonSerialization.deserialize(org.w3c.dom.Element[].class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneArrayOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final org.w3c.dom.Element[] borderValue2 = new org.w3c.dom.Element[] { com.dslplatform.ocd.test.Utils.stringToElement("<document/>"), com.dslplatform.ocd.test.Utils.stringToElement("<TextElement>some text &amp; &lt;stuff&gt;</TextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ElementWithCData>&lt;?xml?&gt;&lt;xml&gt;&lt;!xml!&gt;</ElementWithCData>"), com.dslplatform.ocd.test.Utils.stringToElement("<AtributedElement foo=\"bar\" qwe=\"poi\"/>"), com.dslplatform.ocd.test.Utils.stringToElement("<NestedTextElement><FirstNest><SecondNest>bird</SecondNest></FirstNest></NestedTextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>") };
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final org.w3c.dom.Element[] borderValue2JsonDeserialized = jsonSerialization.deserialize(org.w3c.dom.Element[].class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneArrayOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Xml/OneListOfNullableXmlsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Xml/OneListOfNullableXmlsDefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Xml;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfNullableXmlsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<org.w3c.dom.Element> defaultValue = new java.util.ArrayList<org.w3c.dom.Element>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<org.w3c.dom.Element> defaultValueJsonDeserialized = jsonSerialization.deserializeList(org.w3c.dom.Element.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneListOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<org.w3c.dom.Element> borderValue1 = new java.util.ArrayList<org.w3c.dom.Element>(java.util.Arrays.asList((org.w3c.dom.Element) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<org.w3c.dom.Element> borderValue1JsonDeserialized = jsonSerialization.deserializeList(org.w3c.dom.Element.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneListOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<org.w3c.dom.Element> borderValue2 = new java.util.ArrayList<org.w3c.dom.Element>(java.util.Arrays.asList(com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<org.w3c.dom.Element> borderValue2JsonDeserialized = jsonSerialization.deserializeList(org.w3c.dom.Element.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneListOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.List<org.w3c.dom.Element> borderValue3 = new java.util.ArrayList<org.w3c.dom.Element>(java.util.Arrays.asList(com.dslplatform.ocd.test.Utils.stringToElement("<document/>"), com.dslplatform.ocd.test.Utils.stringToElement("<TextElement>some text &amp; &lt;stuff&gt;</TextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ElementWithCData>&lt;?xml?&gt;&lt;xml&gt;&lt;!xml!&gt;</ElementWithCData>"), com.dslplatform.ocd.test.Utils.stringToElement("<AtributedElement foo=\"bar\" qwe=\"poi\"/>"), com.dslplatform.ocd.test.Utils.stringToElement("<NestedTextElement><FirstNest><SecondNest>bird</SecondNest></FirstNest></NestedTextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.List<org.w3c.dom.Element> borderValue3JsonDeserialized = jsonSerialization.deserializeList(org.w3c.dom.Element.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneListOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.List<org.w3c.dom.Element> borderValue4 = new java.util.ArrayList<org.w3c.dom.Element>(java.util.Arrays.asList((org.w3c.dom.Element) null, com.dslplatform.ocd.test.Utils.stringToElement("<document/>"), com.dslplatform.ocd.test.Utils.stringToElement("<TextElement>some text &amp; &lt;stuff&gt;</TextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ElementWithCData>&lt;?xml?&gt;&lt;xml&gt;&lt;!xml!&gt;</ElementWithCData>"), com.dslplatform.ocd.test.Utils.stringToElement("<AtributedElement foo=\"bar\" qwe=\"poi\"/>"), com.dslplatform.ocd.test.Utils.stringToElement("<NestedTextElement><FirstNest><SecondNest>bird</SecondNest></FirstNest></NestedTextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>")));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.List<org.w3c.dom.Element> borderValue4JsonDeserialized = jsonSerialization.deserializeList(org.w3c.dom.Element.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneListOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Xml/OneListOfOneXmlsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Xml/OneListOfOneXmlsDefaultValueTurtle.java
@@ -1,0 +1,46 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Xml;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneListOfOneXmlsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.List<org.w3c.dom.Element> defaultValue = new java.util.ArrayList<org.w3c.dom.Element>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.List<org.w3c.dom.Element> defaultValueJsonDeserialized = jsonSerialization.deserializeList(org.w3c.dom.Element.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneListOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.List<org.w3c.dom.Element> borderValue1 = new java.util.ArrayList<org.w3c.dom.Element>(java.util.Arrays.asList(com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>")));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.List<org.w3c.dom.Element> borderValue1JsonDeserialized = jsonSerialization.deserializeList(org.w3c.dom.Element.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneListOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.List<org.w3c.dom.Element> borderValue2 = new java.util.ArrayList<org.w3c.dom.Element>(java.util.Arrays.asList(com.dslplatform.ocd.test.Utils.stringToElement("<document/>"), com.dslplatform.ocd.test.Utils.stringToElement("<TextElement>some text &amp; &lt;stuff&gt;</TextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ElementWithCData>&lt;?xml?&gt;&lt;xml&gt;&lt;!xml!&gt;</ElementWithCData>"), com.dslplatform.ocd.test.Utils.stringToElement("<AtributedElement foo=\"bar\" qwe=\"poi\"/>"), com.dslplatform.ocd.test.Utils.stringToElement("<NestedTextElement><FirstNest><SecondNest>bird</SecondNest></FirstNest></NestedTextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.List<org.w3c.dom.Element> borderValue2JsonDeserialized = jsonSerialization.deserializeList(org.w3c.dom.Element.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneListOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Xml/OneSetOfNullableXmlsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Xml/OneSetOfNullableXmlsDefaultValueTurtle.java
@@ -1,0 +1,64 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Xml;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfNullableXmlsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<org.w3c.dom.Element> defaultValue = new java.util.HashSet<org.w3c.dom.Element>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<org.w3c.dom.Element> defaultValueJsonDeserialized = new java.util.HashSet<org.w3c.dom.Element>(jsonSerialization.deserializeList(org.w3c.dom.Element.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneSetOfNullableEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<org.w3c.dom.Element> borderValue1 = new java.util.HashSet<org.w3c.dom.Element>(java.util.Arrays.asList((org.w3c.dom.Element) null));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<org.w3c.dom.Element> borderValue1JsonDeserialized = new java.util.HashSet<org.w3c.dom.Element>(jsonSerialization.deserializeList(org.w3c.dom.Element.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneSetOfNullableEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<org.w3c.dom.Element> borderValue2 = new java.util.HashSet<org.w3c.dom.Element>(java.util.Arrays.asList(com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<org.w3c.dom.Element> borderValue2JsonDeserialized = new java.util.HashSet<org.w3c.dom.Element>(jsonSerialization.deserializeList(org.w3c.dom.Element.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneSetOfNullableEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final java.util.Set<org.w3c.dom.Element> borderValue3 = new java.util.HashSet<org.w3c.dom.Element>(java.util.Arrays.asList(com.dslplatform.ocd.test.Utils.stringToElement("<document/>"), com.dslplatform.ocd.test.Utils.stringToElement("<TextElement>some text &amp; &lt;stuff&gt;</TextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ElementWithCData>&lt;?xml?&gt;&lt;xml&gt;&lt;!xml!&gt;</ElementWithCData>"), com.dslplatform.ocd.test.Utils.stringToElement("<AtributedElement foo=\"bar\" qwe=\"poi\"/>"), com.dslplatform.ocd.test.Utils.stringToElement("<NestedTextElement><FirstNest><SecondNest>bird</SecondNest></FirstNest></NestedTextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>")));
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final java.util.Set<org.w3c.dom.Element> borderValue3JsonDeserialized = new java.util.HashSet<org.w3c.dom.Element>(jsonSerialization.deserializeList(org.w3c.dom.Element.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneSetOfNullableEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final java.util.Set<org.w3c.dom.Element> borderValue4 = new java.util.HashSet<org.w3c.dom.Element>(java.util.Arrays.asList((org.w3c.dom.Element) null, com.dslplatform.ocd.test.Utils.stringToElement("<document/>"), com.dslplatform.ocd.test.Utils.stringToElement("<TextElement>some text &amp; &lt;stuff&gt;</TextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ElementWithCData>&lt;?xml?&gt;&lt;xml&gt;&lt;!xml!&gt;</ElementWithCData>"), com.dslplatform.ocd.test.Utils.stringToElement("<AtributedElement foo=\"bar\" qwe=\"poi\"/>"), com.dslplatform.ocd.test.Utils.stringToElement("<NestedTextElement><FirstNest><SecondNest>bird</SecondNest></FirstNest></NestedTextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>")));
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final java.util.Set<org.w3c.dom.Element> borderValue4JsonDeserialized = new java.util.HashSet<org.w3c.dom.Element>(jsonSerialization.deserializeList(org.w3c.dom.Element.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneSetOfNullableEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Xml/OneSetOfOneXmlsDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Xml/OneSetOfOneXmlsDefaultValueTurtle.java
@@ -1,0 +1,46 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Xml;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneSetOfOneXmlsDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final java.util.Set<org.w3c.dom.Element> defaultValue = new java.util.HashSet<org.w3c.dom.Element>(0);
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final java.util.Set<org.w3c.dom.Element> defaultValueJsonDeserialized = new java.util.HashSet<org.w3c.dom.Element>(jsonSerialization.deserializeList(org.w3c.dom.Element.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneSetOfOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final java.util.Set<org.w3c.dom.Element> borderValue1 = new java.util.HashSet<org.w3c.dom.Element>(java.util.Arrays.asList(com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>")));
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final java.util.Set<org.w3c.dom.Element> borderValue1JsonDeserialized = new java.util.HashSet<org.w3c.dom.Element>(jsonSerialization.deserializeList(org.w3c.dom.Element.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneSetOfOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final java.util.Set<org.w3c.dom.Element> borderValue2 = new java.util.HashSet<org.w3c.dom.Element>(java.util.Arrays.asList(com.dslplatform.ocd.test.Utils.stringToElement("<document/>"), com.dslplatform.ocd.test.Utils.stringToElement("<TextElement>some text &amp; &lt;stuff&gt;</TextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ElementWithCData>&lt;?xml?&gt;&lt;xml&gt;&lt;!xml!&gt;</ElementWithCData>"), com.dslplatform.ocd.test.Utils.stringToElement("<AtributedElement foo=\"bar\" qwe=\"poi\"/>"), com.dslplatform.ocd.test.Utils.stringToElement("<NestedTextElement><FirstNest><SecondNest>bird</SecondNest></FirstNest></NestedTextElement>"), com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>")));
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final java.util.Set<org.w3c.dom.Element> borderValue2JsonDeserialized = new java.util.HashSet<org.w3c.dom.Element>(jsonSerialization.deserializeList(org.w3c.dom.Element.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length));
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneSetOfOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+}

--- a/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Xml/OneXmlDefaultValueTurtle.java
+++ b/core/src/test/java-generated/com/dslplatform/ocd/test/javatest/property/turtles/Xml/OneXmlDefaultValueTurtle.java
@@ -1,0 +1,73 @@
+package com.dslplatform.ocd.test.javatest.property.turtles.Xml;
+
+import com.dslplatform.client.JsonSerialization;
+import com.dslplatform.client.Bootstrap;
+import com.dslplatform.patterns.Bytes;
+import com.dslplatform.patterns.ServiceLocator;
+import java.io.IOException;
+
+public class OneXmlDefaultValueTurtle {
+
+    private static JsonSerialization jsonSerialization;
+
+    @org.junit.BeforeClass
+    public static void initializeJsonSerialization() throws IOException {
+        final ServiceLocator locator = Bootstrap.init(new java.io.ByteArrayInputStream(
+                "username=unused\nproject-id=unused\napi-url=unused\npackage-name=unused".getBytes("UTF-8")));
+        jsonSerialization = locator.resolve(JsonSerialization.class);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testDefaultValueEquality() throws IOException {
+        final org.w3c.dom.Element defaultValue = com.dslplatform.ocd.test.Utils.stringToElement("<document/>");
+        final Bytes defaultValueJsonSerialized = jsonSerialization.serialize(defaultValue);
+        final org.w3c.dom.Element defaultValueJsonDeserialized = jsonSerialization.deserialize(org.w3c.dom.Element.class, defaultValueJsonSerialized.content, defaultValueJsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneEquals(defaultValue, defaultValueJsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue1Equality() throws IOException {
+        final org.w3c.dom.Element borderValue1 = com.dslplatform.ocd.test.Utils.stringToElement("<TextElement>some text &amp; &lt;stuff&gt;</TextElement>");
+        final Bytes borderValue1JsonSerialized = jsonSerialization.serialize(borderValue1);
+        final org.w3c.dom.Element borderValue1JsonDeserialized = jsonSerialization.deserialize(org.w3c.dom.Element.class, borderValue1JsonSerialized.content, borderValue1JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneEquals(borderValue1, borderValue1JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue2Equality() throws IOException {
+        final org.w3c.dom.Element borderValue2 = com.dslplatform.ocd.test.Utils.stringToElement("<ElementWithCData>&lt;?xml?&gt;&lt;xml&gt;&lt;!xml!&gt;</ElementWithCData>");
+        final Bytes borderValue2JsonSerialized = jsonSerialization.serialize(borderValue2);
+        final org.w3c.dom.Element borderValue2JsonDeserialized = jsonSerialization.deserialize(org.w3c.dom.Element.class, borderValue2JsonSerialized.content, borderValue2JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneEquals(borderValue2, borderValue2JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue3Equality() throws IOException {
+        final org.w3c.dom.Element borderValue3 = com.dslplatform.ocd.test.Utils.stringToElement("<AtributedElement foo=\"bar\" qwe=\"poi\"/>");
+        final Bytes borderValue3JsonSerialized = jsonSerialization.serialize(borderValue3);
+        final org.w3c.dom.Element borderValue3JsonDeserialized = jsonSerialization.deserialize(org.w3c.dom.Element.class, borderValue3JsonSerialized.content, borderValue3JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneEquals(borderValue3, borderValue3JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue4Equality() throws IOException {
+        final org.w3c.dom.Element borderValue4 = com.dslplatform.ocd.test.Utils.stringToElement("<NestedTextElement><FirstNest><SecondNest>bird</SecondNest></FirstNest></NestedTextElement>");
+        final Bytes borderValue4JsonSerialized = jsonSerialization.serialize(borderValue4);
+        final org.w3c.dom.Element borderValue4JsonDeserialized = jsonSerialization.deserialize(org.w3c.dom.Element.class, borderValue4JsonSerialized.content, borderValue4JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneEquals(borderValue4, borderValue4JsonDeserialized);
+    }
+
+    /* Equality test to check if assertions / JSON serialization works */
+    @org.junit.Test
+    public void testBorderValue5Equality() throws IOException {
+        final org.w3c.dom.Element borderValue5 = com.dslplatform.ocd.test.Utils.stringToElement("<ns3000:NamespacedElement/>");
+        final Bytes borderValue5JsonSerialized = jsonSerialization.serialize(borderValue5);
+        final org.w3c.dom.Element borderValue5JsonDeserialized = jsonSerialization.deserialize(org.w3c.dom.Element.class, borderValue5JsonSerialized.content, borderValue5JsonSerialized.length);
+        com.dslplatform.ocd.javaasserts.XmlAsserts.assertOneEquals(borderValue5, borderValue5JsonDeserialized);
+    }
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -113,7 +113,10 @@ object Build extends Build with Default with Dependencies {
       , logback % "test"
       , xmlUnit % "test"
       )
-    , unmanagedSourceDirectories in Test := Seq((javaSource in Test).value)
+    , unmanagedSourceDirectories in Test := Seq(
+        (javaSource in Test).value
+      , sourceDirectory.value / "test" / "java-generated"
+      )
     , testOptions += Tests.Argument(TestFrameworks.JUnit, "-q", "-v")
     , EclipseKeys.createSrc := EclipseCreateSrc.Default + EclipseCreateSrc.Resource
     , createVersionProperties


### PR DESCRIPTION
Generated serialization tests can be off by commenting this line in Bulid.scala:

    sourceDirectory.value / "test" / "java-generated" 