### PR TITLE
Added missing Guards

### DIFF
--- a/core/src/main/java/com/dslplatform/client/Guards.java
+++ b/core/src/main/java/com/dslplatform/client/Guards.java
@@ -30,6 +30,16 @@ public abstract class Guards {
 		}
 	}
 
+	public static <T> void checkNulls(final LinkedList<T> values) {
+		if (values == null) return;
+
+		int i = 0;
+		for (final T value : values) {
+			if (value == null) throw new IllegalArgumentException("Element at index " + i + " was a null value, which is not permitted.");
+			i++;
+		}
+	}
+
 	public static void checkScale(final BigDecimal value, final int scale) {
 		if (value == null) return;
 		try {
@@ -64,6 +74,21 @@ public abstract class Guards {
 			} catch (final ArithmeticException e) {
 				throw new IllegalArgumentException("Invalid value for element at index " + i + ". Decimal places allowed: " + scale + ". Value: " + value, e);
 			}
+		}
+	}
+
+	public static void checkScale(final LinkedList<BigDecimal> values, final int scale) {
+		if (values == null) return;
+
+		int i = 0;
+		for (final BigDecimal value : values) {
+			try {
+				if (value != null) value.setScale(scale);
+			} catch (final ArithmeticException e) {
+				throw new IllegalArgumentException(
+						"Invalid value for element at index " + i + ". Decimal places allowed: " + scale + ". Value: " + value, e);
+			}
+			i++;
 		}
 	}
 
@@ -138,14 +163,22 @@ public abstract class Guards {
 		return result;
 	}
 
+	public static Queue<BigDecimal> setScale(final Queue<BigDecimal> values, final int scale) {
+		if (values == null) return null;
+
+		final Queue<BigDecimal> result = new ArrayDeque<BigDecimal>();
+		for (final BigDecimal value : values) {
+			if (value == null) throw new NullPointerException("Default Queue implementation (java.util.ArrayDeque) does not support null elements!");
+			result.add(setScale(value, scale));
+		}
+		return result;
+	}
+
 	public static LinkedList<BigDecimal> setScale(final LinkedList<BigDecimal> values, final int scale) {
 		if (values == null) return null;
 
 		final LinkedList<BigDecimal> result = new LinkedList<BigDecimal>();
-		for (int i = 0; i < values.size(); i++) {
-			final BigDecimal value = values.get(i);
-			result.add(value != null ? setScale(value, scale) : null);
-		}
+		for (final BigDecimal value : values) result.add(value != null ? setScale(value, scale) : null);
 		return result;
 	}
 
@@ -182,6 +215,17 @@ public abstract class Guards {
 			final String value = values.get(i);
 			if (value != null && value.length() > length) throw new IllegalArgumentException(
 					"Invalid value for element at index " + i + ". Maximum length allowed: " + length + ". Value: " + value);
+		}
+	}
+
+	public static void checkLength(final LinkedList<String> values, final int length) {
+		if (values == null) return;
+
+		int i = 0;
+		for (final String value : values) {
+			if (value != null && value.length() > length) throw new IllegalArgumentException(
+					"Invalid value for element at index " + i + ". Maximum length allowed: " + length + ". Value: " + value);
+			i++;
 		}
 	}
 

--- a/core/src/test/java/com/dslplatform/client/GuardsCheckSpeedTest.java
+++ b/core/src/test/java/com/dslplatform/client/GuardsCheckSpeedTest.java
@@ -1,0 +1,122 @@
+package com.dslplatform.client;
+
+import java.math.BigDecimal;
+import java.util.*;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class GuardsCheckSpeedTest {
+	private static List<BigDecimal> zeroes;
+	private static List<String> empties;
+
+	@BeforeClass
+	public static void initializeZeroes() {
+		zeroes = new ArrayList<BigDecimal>();
+		empties = new ArrayList<String>();
+		for (int i = 0; i < 50000; i ++) {
+			zeroes.add(BigDecimal.ZERO);
+			empties.add("");
+		}
+	}
+
+	@Test
+	public void testArrayCheckSpeed() {
+		final BigDecimal[] numbers = zeroes.toArray(new BigDecimal[zeroes.size()]);
+		final String[] strings = empties.toArray(new String[empties.size()]);
+ 		final long startAt = System.nanoTime();
+		Guards.checkNulls(numbers);
+		Guards.checkScale(numbers, 0);
+		Guards.checkNulls(strings);
+		Guards.checkLength(strings, 0);
+		final long endAt = System.nanoTime();
+		final long tookMs = (endAt - startAt) / 1000000;
+		Assert.assertTrue("Checks took " + tookMs + "ms (should be ~0ms)", tookMs < 1000);
+	}
+
+	@Test
+	public void testListCheckSpeed() {
+		final List<BigDecimal> numbers = new ArrayList<BigDecimal>(zeroes);
+		final List<String> strings = new ArrayList<String>(empties);
+		final long startAt = System.nanoTime();
+		Guards.checkNulls(numbers);
+		Guards.checkScale(numbers, 0);
+		Guards.checkNulls(strings);
+		Guards.checkLength(strings, 0);
+		final long endAt = System.nanoTime();
+		final long tookMs = (endAt - startAt) / 1000000;
+		Assert.assertTrue("Checks took " + tookMs + "ms (should be ~0ms)", tookMs < 1000);
+	}
+
+	@Test
+	public void testSetCheckSpeed() {
+		final Set<BigDecimal> numbers = new HashSet<BigDecimal>(zeroes);
+		final Set<String> strings = new HashSet<String>(empties);
+		final long startAt = System.nanoTime();
+		Guards.checkNulls(numbers);
+		Guards.checkScale(numbers, 0);
+		Guards.checkNulls(strings);
+		Guards.checkLength(strings, 0);
+		final long endAt = System.nanoTime();
+		final long tookMs = (endAt - startAt) / 1000000;
+		Assert.assertTrue("Checks took " + tookMs + "ms (should be ~0ms)", tookMs < 1000);
+	}
+
+	@Test
+	public void testQueueCheckSpeed() {
+		final Queue<BigDecimal> numbers = new ArrayDeque<BigDecimal>(zeroes);
+		final Queue<String> strings = new ArrayDeque<String>(empties);
+		final long startAt = System.nanoTime();
+		Guards.checkNulls(numbers);
+		Guards.checkScale(numbers, 0);
+		Guards.checkNulls(strings);
+		Guards.checkLength(strings, 0);
+		final long endAt = System.nanoTime();
+		final long tookMs = (endAt - startAt) / 1000000;
+		Assert.assertTrue("Checks took " + tookMs + "ms (should be ~0ms)", tookMs < 1000);
+	}
+
+	@Test
+	public void testLinkedListCheckSpeed() {
+		final LinkedList<BigDecimal> numbers = new LinkedList<BigDecimal>(zeroes);
+		final LinkedList<String> strings = new LinkedList<String>(empties);
+		final long startAt = System.nanoTime();
+		Guards.checkNulls(numbers);
+		Guards.checkScale(numbers, 0);
+		Guards.checkNulls(strings);
+		Guards.checkLength(strings, 0);
+		final long endAt = System.nanoTime();
+		final long tookMs = (endAt - startAt) / 1000000;
+		Assert.assertTrue("Checks took " + tookMs + "ms (should be ~0ms)", tookMs < 1000);
+	}
+
+	@Test
+	@SuppressWarnings("serial")
+	public void testStackCheckSpeed() {
+		final Stack<BigDecimal> numbers = new Stack<BigDecimal>() {{ addAll(zeroes); }};
+		final Stack<String> strings = new Stack<String>() {{ addAll(empties); }};
+		final long startAt = System.nanoTime();
+		Guards.checkNulls(numbers);
+		Guards.checkScale(numbers, 0);
+		Guards.checkNulls(strings);
+		Guards.checkLength(strings, 0);
+		final long endAt = System.nanoTime();
+		final long tookMs = (endAt - startAt) / 1000000;
+		Assert.assertTrue("Checks took " + tookMs + "ms (should be ~0ms)", tookMs < 1000);
+	}
+
+	@Test
+	public void testVectorCheckSpeed() {
+		final Vector<BigDecimal> numbers = new Vector<BigDecimal>(zeroes);
+		final Vector<String> strings = new Vector<String>(empties);
+		final long startAt = System.nanoTime();
+		Guards.checkNulls(numbers);
+		Guards.checkScale(numbers, 0);
+		Guards.checkNulls(strings);
+		Guards.checkLength(strings, 0);
+		final long endAt = System.nanoTime();
+		final long tookMs = (endAt - startAt) / 1000000;
+		Assert.assertTrue("Checks took " + tookMs + "ms (should be ~0ms)", tookMs < 1000);
+	}
+}

--- a/core/src/test/java/com/dslplatform/client/GuardsScaleTests.java
+++ b/core/src/test/java/com/dslplatform/client/GuardsScaleTests.java
@@ -1,0 +1,142 @@
+package com.dslplatform.client;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.*;
+import org.junit.Test;
+
+import com.dslplatform.ocd.javaasserts.DecimalAsserts;
+
+public class GuardsScaleTests {
+	private static final BigDecimal[] PIES = new BigDecimal[] {
+		new BigDecimal("3.14159265358979323846264"),
+		new BigDecimal("2.14159265358979323846264"),
+		new BigDecimal("1.14159265358979323846264"),
+		null,
+		new BigDecimal("-1.14159265358979323846264"),
+		new BigDecimal("-2.14159265358979323846264"),
+		new BigDecimal("-3.14159265358979323846264")
+	};
+
+	@Test
+	public void testArrayScaling() {
+		final BigDecimal[] original = PIES;
+		final BigDecimal[] result = Guards.setScale(original, 3);
+		Guards.checkScale(result, 3);
+
+		DecimalAsserts.assertOneArrayOfNullableEquals(result, new BigDecimal[] {
+				new BigDecimal("3.1411").setScale(3, RoundingMode.CEILING),
+				new BigDecimal("2.1415").setScale(3, RoundingMode.HALF_EVEN),
+				new BigDecimal("1.1424").setScale(3, RoundingMode.HALF_UP),
+				null,
+				new BigDecimal("-1.1411").setScale(3, RoundingMode.FLOOR),
+				new BigDecimal("-2.1425").setScale(3, RoundingMode.HALF_DOWN),
+				new BigDecimal("-3.1420").setScale(3, RoundingMode.UNNECESSARY)});
+	}
+
+	@Test
+	public void testListScaling() {
+		final List<BigDecimal> original = Arrays.asList(PIES);
+		final List<BigDecimal> result = Guards.setScale(original, 3);
+		Guards.checkScale(result, 3);
+
+		DecimalAsserts.assertOneListOfNullableEquals(result, Arrays.asList(
+				new BigDecimal("3.1411").setScale(3, RoundingMode.CEILING),
+				new BigDecimal("2.1415").setScale(3, RoundingMode.HALF_EVEN),
+				new BigDecimal("1.1424").setScale(3, RoundingMode.HALF_UP),
+				null,
+				new BigDecimal("-1.1411").setScale(3, RoundingMode.FLOOR),
+				new BigDecimal("-2.1425").setScale(3, RoundingMode.HALF_DOWN),
+				new BigDecimal("-3.1420").setScale(3, RoundingMode.UNNECESSARY)));
+	}
+
+	@Test
+	public void testSetScaling() {
+		final Set<BigDecimal> original = new HashSet<BigDecimal>(Arrays.asList(PIES));
+		final Set<BigDecimal> result = Guards.setScale(original, 3);
+		Guards.checkScale(result, 3);
+
+		DecimalAsserts.assertOneSetOfNullableEquals(result, new HashSet<BigDecimal>(Arrays.asList(
+				new BigDecimal("1.1424").setScale(3, RoundingMode.HALF_UP),
+				new BigDecimal("-2.1425").setScale(3, RoundingMode.HALF_DOWN),
+				new BigDecimal("-1.1411").setScale(3, RoundingMode.FLOOR),
+				null, // order intentionally shuffled
+				new BigDecimal("-3.1420").setScale(3, RoundingMode.UNNECESSARY),
+				new BigDecimal("3.1411").setScale(3, RoundingMode.CEILING),
+				new BigDecimal("2.1415").setScale(3, RoundingMode.HALF_EVEN))));
+
+	}
+
+	@Test(expected=NullPointerException.class)
+	public void testNullableQueueElementScaling() {
+		final Queue<BigDecimal> original = new LinkedList<BigDecimal>(Arrays.asList(PIES));
+		Guards.setScale(original, 3);
+	}
+
+	@Test
+	public void testQueueScaling() {
+		final List<BigDecimal> temp = new ArrayList<BigDecimal>(Arrays.asList(PIES));
+		temp.set(3, BigDecimal.ZERO); // convert null to zero
+		final Queue<BigDecimal> original = new ArrayDeque<BigDecimal>(temp);
+		final Queue<BigDecimal> result = Guards.setScale(original, 3);
+		Guards.checkScale(result, 3);
+
+		DecimalAsserts.assertOneQueueOfOneEquals(result, new ArrayDeque<BigDecimal>(Arrays.asList(
+				new BigDecimal("3.1411").setScale(3, RoundingMode.CEILING),
+				new BigDecimal("2.1415").setScale(3, RoundingMode.HALF_EVEN),
+				new BigDecimal("1.1424").setScale(3, RoundingMode.HALF_UP),
+				new BigDecimal("0.0009").setScale(3, RoundingMode.DOWN),
+				new BigDecimal("-1.1411").setScale(3, RoundingMode.FLOOR),
+				new BigDecimal("-2.1425").setScale(3, RoundingMode.HALF_DOWN),
+				new BigDecimal("-3.1420").setScale(3, RoundingMode.UNNECESSARY))));
+	}
+
+	@Test
+	public void testLinkedListScaling() {
+		final LinkedList<BigDecimal> original = new LinkedList<BigDecimal>(Arrays.asList(PIES));
+		final LinkedList<BigDecimal> result = Guards.setScale(original, 3);
+		Guards.checkScale(result, 3); // special checkScale for LinkedList so that it doesn't invoke RandomAccess version from List instead
+
+		DecimalAsserts.assertOneLinkedListOfNullableEquals(result, new LinkedList<BigDecimal>(Arrays.asList(
+				new BigDecimal("3.1411").setScale(3, RoundingMode.CEILING),
+				new BigDecimal("2.1415").setScale(3, RoundingMode.HALF_EVEN),
+				new BigDecimal("1.1424").setScale(3, RoundingMode.HALF_UP),
+				null,
+				new BigDecimal("-1.1411").setScale(3, RoundingMode.FLOOR),
+				new BigDecimal("-2.1425").setScale(3, RoundingMode.HALF_DOWN),
+				new BigDecimal("-3.1420").setScale(3, RoundingMode.UNNECESSARY))));
+	}
+
+	@Test
+	@SuppressWarnings("serial")
+	public void testStackScaling() {
+		final Stack<BigDecimal> original = new Stack<BigDecimal>() {{ addAll(Arrays.asList(PIES)); }};
+		final Stack<BigDecimal> result = Guards.setScale(original, 3);
+		Guards.checkScale(result, 3);
+
+		DecimalAsserts.assertOneStackOfNullableEquals(result, new Stack<BigDecimal>() {{ addAll(Arrays.asList(
+				new BigDecimal("3.1411").setScale(3, RoundingMode.CEILING),
+				new BigDecimal("2.1415").setScale(3, RoundingMode.HALF_EVEN),
+				new BigDecimal("1.1424").setScale(3, RoundingMode.HALF_UP),
+				null,
+				new BigDecimal("-1.1411").setScale(3, RoundingMode.FLOOR),
+				new BigDecimal("-2.1425").setScale(3, RoundingMode.HALF_DOWN),
+				new BigDecimal("-3.1420").setScale(3, RoundingMode.UNNECESSARY))); }});
+	}
+
+	@Test
+	public void testVectorScaling() {
+		final Vector<BigDecimal> original = new Vector<BigDecimal>(Arrays.asList(PIES));
+		final Vector<BigDecimal> result = Guards.setScale(original, 3);
+		Guards.checkScale(result, 3);
+
+		DecimalAsserts.assertOneVectorOfNullableEquals(result, new Vector<BigDecimal>(Arrays.asList(
+				new BigDecimal("3.1411").setScale(3, RoundingMode.CEILING),
+				new BigDecimal("2.1415").setScale(3, RoundingMode.HALF_EVEN),
+				new BigDecimal("1.1424").setScale(3, RoundingMode.HALF_UP),
+				null,
+				new BigDecimal("-1.1411").setScale(3, RoundingMode.FLOOR),
+				new BigDecimal("-2.1425").setScale(3, RoundingMode.HALF_DOWN),
+				new BigDecimal("-3.1420").setScale(3, RoundingMode.UNNECESSARY))));
+	}
+}


### PR DESCRIPTION
setScale tweaks: Added support for Queue<BigDecimal>

LinkedList is not RandomAccess, switched to iterator for traversal.
Create specialized checks for nulls and scale for LinkedList to prevent it from using the List (RandomAccess) interface

Default Queue implementation (ArrayDeque) doesn't support null values, so throw error if nulls were provided

Added setScale tests for all current collection types
